### PR TITLE
LayoutImpl now reads distributed state (store + process_group) from a…

### DIFF
--- a/python/csrc/pylayout.cpp
+++ b/python/csrc/pylayout.cpp
@@ -2,6 +2,9 @@
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
+// C/C++
+#include <memory>
+
 // fmt
 #include <fmt/format.h>
 
@@ -18,6 +21,28 @@
 #include "pyoptions.hpp"
 
 namespace py = pybind11;
+
+namespace {
+
+void sync_layout_distributed_state_from_torch() {
+  auto c10d = py::module::import("torch.distributed.distributed_c10d");
+
+  auto process_group =
+      c10d.attr("_get_default_group")()
+          .cast<c10::intrusive_ptr<c10d::ProcessGroup>>();
+  auto store =
+      c10d.attr("_get_default_store")().cast<at::intrusive_ptr<c10d::Store>>();
+
+  snap::LayoutImpl::set_distributed_state(store, process_group);
+}
+
+void ensure_layout_distributed_state(const snap::LayoutOptions& options) {
+  if (options != nullptr && !options->no_backend()) {
+    sync_layout_distributed_state_from_torch();
+  }
+}
+
+}  // namespace
 
 void bind_layout(py::module &m) {
   auto pyLayoutOptions =
@@ -66,7 +91,11 @@ void bind_layout(py::module &m) {
       py::class_<snap::SlabLayoutImpl, snap::LayoutImpl,
                  std::shared_ptr<snap::SlabLayoutImpl>>(m, "SlabLayout");
 
-  pySlabLayout.def(py::init<snap::LayoutOptions>(), py::arg("options"))
+  pySlabLayout.def(py::init([](const snap::LayoutOptions& options) {
+                     ensure_layout_distributed_state(options);
+                     return std::make_shared<snap::SlabLayoutImpl>(options);
+                   }),
+                   py::arg("options"))
       .def_readonly("options", &snap::SlabLayoutImpl::options)
       .def("rank_of", &snap::SlabLayoutImpl::rank_of)
       .def("loc_of", &snap::SlabLayoutImpl::loc_of)
@@ -90,7 +119,11 @@ void bind_layout(py::module &m) {
       py::class_<snap::CubedLayoutImpl, snap::LayoutImpl,
                  std::shared_ptr<snap::CubedLayoutImpl>>(m, "CubedLayout");
 
-  pyCubedLayout.def(py::init<snap::LayoutOptions>(), py::arg("options"))
+  pyCubedLayout.def(py::init([](const snap::LayoutOptions& options) {
+                      ensure_layout_distributed_state(options);
+                      return std::make_shared<snap::CubedLayoutImpl>(options);
+                    }),
+                    py::arg("options"))
       .def_readonly("options", &snap::CubedLayoutImpl::options)
       .def("rank_of", &snap::CubedLayoutImpl::rank_of)
       .def("loc_of", &snap::CubedLayoutImpl::loc_of)
@@ -116,7 +149,11 @@ void bind_layout(py::module &m) {
           m, "CubedSphereLayout");
 
   pyCubedSphereLayout.def(py::init<>())
-      .def(py::init<snap::LayoutOptions>(), py::arg("options"))
+      .def(py::init([](const snap::LayoutOptions& options) {
+             ensure_layout_distributed_state(options);
+             return std::make_shared<snap::CubedSphereLayoutImpl>(options);
+           }),
+           py::arg("options"))
       .def_readonly("options", &snap::CubedSphereLayoutImpl::options)
       .def("rank_of", &snap::CubedSphereLayoutImpl::rank_of)
       .def("loc_of", &snap::CubedSphereLayoutImpl::loc_of)
@@ -140,5 +177,7 @@ void bind_layout(py::module &m) {
   auto m_dist = m.def_submodule("distributed", "Distributed module");
   m_dist.def("get_rank", &snap::get_rank)
       .def("get_local_rank", &snap::get_local_rank)
+      .def("sync_process_group", &sync_layout_distributed_state_from_torch)
+      .def("has_process_group", &snap::LayoutImpl::has_distributed_state)
       .def("get_layout", &snap::MeshBlockImpl::get_layout);
 }

--- a/python/snapy/layout.pyi
+++ b/python/snapy/layout.pyi
@@ -330,6 +330,16 @@ class distributed:
         ...
 
     @staticmethod
+    def sync_process_group() -> None:
+        """Bind the default torch.distributed process group/store to snapy."""
+        ...
+
+    @staticmethod
+    def has_process_group() -> bool:
+        """Check whether snapy has a bound distributed process group."""
+        ...
+
+    @staticmethod
     def get_layout(*args):  # Returns Layout
         """Get the layout object."""
         ...

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -1,12 +1,11 @@
 // yaml
 #include <yaml-cpp/yaml.h>
 
+// C/C++
+#include <mutex>
+
 // base
 #include <configure.h>  // gloo and nccl
-
-// torch
-#include <torch/csrc/distributed/c10d/ProcessGroupGloo.hpp>
-#include <torch/csrc/distributed/c10d/TCPStore.hpp>
 
 // snap
 #include <snap/mesh/meshblock.hpp>
@@ -16,6 +15,42 @@
 #include "layout.hpp"
 
 namespace snap {
+
+namespace {
+struct DistributedState {
+  at::intrusive_ptr<c10d::Store> store;
+  c10::intrusive_ptr<c10d::ProcessGroup> process_group;
+};
+
+DistributedState& global_distributed_state() {
+  static DistributedState state;
+  return state;
+}
+
+std::mutex& global_distributed_state_mutex() {
+  static std::mutex mu;
+  return mu;
+}
+}  // namespace
+
+void LayoutImpl::set_distributed_state(
+    const at::intrusive_ptr<c10d::Store>& store_,
+    const c10::intrusive_ptr<c10d::ProcessGroup>& process_group_) {
+  TORCH_CHECK(store_ != nullptr, "[Layout] store must not be null");
+  TORCH_CHECK(process_group_ != nullptr,
+              "[Layout] process_group must not be null");
+
+  std::lock_guard<std::mutex> guard(global_distributed_state_mutex());
+  auto& state = global_distributed_state();
+  state.store = store_;
+  state.process_group = process_group_;
+}
+
+bool LayoutImpl::has_distributed_state() {
+  std::lock_guard<std::mutex> guard(global_distributed_state_mutex());
+  auto& state = global_distributed_state();
+  return state.store != nullptr && state.process_group != nullptr;
+}
 
 LayoutOptionsImpl::LayoutOptionsImpl() {
   // These enrionment variables will be set by torch.distributed.launch
@@ -306,16 +341,23 @@ void LayoutImpl::_init_backend() {
               << "] Initializing distributed environment\n";
   }
 
-  // 1. Build the store
-  c10d::TCPStoreOptions store_op;
+  {
+    std::lock_guard<std::mutex> guard(global_distributed_state_mutex());
+    auto& state = global_distributed_state();
+    TORCH_CHECK(
+        state.store != nullptr && state.process_group != nullptr,
+        "[Layout] distributed state is not initialized. Call "
+        "`torch.distributed.init_process_group(...)` in Python and then "
+        "`snapy.distributed.sync_process_group()` before creating layout "
+        "objects.");
+    store = state.store;
+    process_group = state.process_group;
+  }
 
-  store_op.port = options->master_port();
-  store_op.numWorkers = options->world_size();
-  store_op.isServer = is_root();
+  options->rank(process_group->getRank());
+  options->world_size(process_group->getSize());
 
-  store = at::make_intrusive<c10d::TCPStore>(options->master_addr(), store_op);
-
-  // 2. Create ProcessGroup based on backend
+  // Resolve backend from the process group initialized in Python.
   if (options->backend() == "gloo") {
     _init_gloo();
   } else if (options->backend() == "nccl") {
@@ -323,6 +365,8 @@ void LayoutImpl::_init_backend() {
   } else {
     throw std::runtime_error("Unsupported BACKEND=" + options->backend());
   }
+  TORCH_CHECK(pg != nullptr, "[Layout] failed to resolve backend=",
+              options->backend());
 
   /*c10d::BarrierOptions op;
   op.device_ids = {options->local_rank()};
@@ -343,11 +387,11 @@ void LayoutImpl::_init_gloo() {
               << "] Using Gloo backend on CPU\n";
   }
 
-  auto opts = c10d::ProcessGroupGloo::Options::create();
-  opts->devices.push_back(c10d::ProcessGroupGloo::createDefaultDevice());
-
-  pg = std::make_shared<c10d::ProcessGroupGloo>(store, options->rank(),
-                                                options->world_size(), opts);
+  TORCH_CHECK(process_group != nullptr,
+              "[Layout] process group is not available for gloo backend");
+  pg = process_group->getBackend(c10::DeviceType::CPU);
+  TORCH_CHECK(pg != nullptr, "[Layout] gloo backend is unavailable in the "
+                             "process group initialized from Python");
 }
 
 #ifdef NOT_USE_C10D_NCCL

--- a/src/layout/layout.cu
+++ b/src/layout/layout.cu
@@ -13,8 +13,6 @@
 namespace snap {
 
 void LayoutImpl::_init_nccl() {
-  auto opts = c10d::ProcessGroupNCCL::Options::create();
-
   // Rank -> GPU mapping
   int device_index;
   if (options->device_id() < 0) {
@@ -29,8 +27,11 @@ void LayoutImpl::_init_nccl() {
   torch::Device device(torch::kCUDA, device_index);
   c10::cuda::set_device(device_index);
 
-  pg = std::make_shared<c10d::ProcessGroupNCCL>(store, options->rank(),
-                                                options->world_size(), opts);
+  TORCH_CHECK(process_group != nullptr,
+              "[Layout] process group is not available for nccl backend");
+  pg = process_group->getBackend(c10::DeviceType::CUDA);
+  TORCH_CHECK(pg != nullptr, "[Layout] nccl backend is unavailable in the "
+                             "process group initialized from Python");
   pg->setBoundDeviceId(device);
 
   if (options->verbose()) {
@@ -43,13 +44,19 @@ void LayoutImpl::_init_nccl() {
 
 void LayoutImpl::_group_start() const {
   if (options->backend() == "nccl") {
-    std::dynamic_pointer_cast<c10d::ProcessGroupNCCL>(pg)->groupStart();
+    auto* nccl_pg = dynamic_cast<c10d::ProcessGroupNCCL*>(pg.get());
+    TORCH_CHECK(nccl_pg != nullptr,
+                "[Layout] expected ProcessGroupNCCL for backend=nccl");
+    nccl_pg->groupStart();
   }
 }
 
 void LayoutImpl::_group_end() const {
   if (options->backend() == "nccl") {
-    std::dynamic_pointer_cast<c10d::ProcessGroupNCCL>(pg)->groupEnd();
+    auto* nccl_pg = dynamic_cast<c10d::ProcessGroupNCCL*>(pg.get());
+    TORCH_CHECK(nccl_pg != nullptr,
+                "[Layout] expected ProcessGroupNCCL for backend=nccl");
+    nccl_pg->groupEnd();
   }
 }
 

--- a/src/layout/layout.hpp
+++ b/src/layout/layout.hpp
@@ -11,8 +11,8 @@
 #include <torch/nn/modules/common.h>
 
 #include <torch/csrc/distributed/c10d/Store.hpp>
-// #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/Backend.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 
 // snap
 #include <snap/snap.h>
@@ -139,6 +139,11 @@ class MeshBlockImpl;
 
 class LayoutImpl {
  public:
+  static void set_distributed_state(
+      const at::intrusive_ptr<c10d::Store> &store,
+      const c10::intrusive_ptr<c10d::ProcessGroup> &process_group);
+  static bool has_distributed_state();
+
   static std::shared_ptr<LayoutImpl> create(LayoutOptions const &opts,
                                             torch::nn::Module *p = nullptr,
                                             std::string const &name = "layout");
@@ -152,7 +157,8 @@ class LayoutImpl {
 
   //! submodules
   at::intrusive_ptr<c10d::Store> store;
-  std::shared_ptr<c10d::Backend> pg;
+  c10::intrusive_ptr<c10d::Backend> pg;
+  c10::intrusive_ptr<c10d::ProcessGroup> process_group;
 
   //! options with which this `Layout` was constructed
   LayoutOptions options;


### PR DESCRIPTION
### What changed
- LayoutImpl no longer creates TCPStore or ProcessGroup* in C++.
- LayoutImpl now reads distributed state (store + process_group) from a shared state set from Python, then resolves backend (gloo/nccl) from that process group.
- Added APIs:
  - LayoutImpl::set_distributed_state(...)
  - LayoutImpl::has_distributed_state()
- Python bindings now pull default state from PyTorch after torch.distributed.init_process_group(...) and register it into LayoutImpl.
  - Auto-sync happens when creating SlabLayout/CubedLayout/CubedSphereLayout.
  - Also exposed explicit API: snapy.distributed.sync_process_group()
  - Added snapy.distributed.has_process_group().

### Files changed
[layout.hpp](https://file+.vscode-resource.vscode-cdn.net/Users/zyhu/.vscode/extensions/openai.chatgpt-26.304.20706-darwin-x64/webview/#)
[layout.cpp](https://file+.vscode-resource.vscode-cdn.net/Users/zyhu/.vscode/extensions/openai.chatgpt-26.304.20706-darwin-x64/webview/#)
[layout.cu](https://file+.vscode-resource.vscode-cdn.net/Users/zyhu/.vscode/extensions/openai.chatgpt-26.304.20706-darwin-x64/webview/#)
[pylayout.cpp](https://file+.vscode-resource.vscode-cdn.net/Users/zyhu/.vscode/extensions/openai.chatgpt-26.304.20706-darwin-x64/webview/#)
[layout.pyi](https://file+.vscode-resource.vscode-cdn.net/Users/zyhu/.vscode/extensions/openai.chatgpt-26.304.20706-darwin-x64/webview/#)

### Behavioral note
You now need Python-side init first:
- torch.distributed.init_process_group(...)
- then create layout objects (auto-sync), or call snapy.distributed.sync_process_group() explicitly.