### PR TITLE
Fix relax bottom composition ghost-zone handling

### DIFF
--- a/src/forcing/relax_bot_comp.cpp
+++ b/src/forcing/relax_bot_comp.cpp
@@ -83,29 +83,31 @@ torch::Tensor RelaxBotCompImpl::forward(torch::Tensor du, torch::Tensor w,
       phydro->pmb->part({0, 0, -1}, PartOptions().exterior(false).depth(1));
   auto bottom3 = phydro->pmb->part(
       {0, 0, -1}, PartOptions().exterior(false).depth(1).ndim(3));
-  auto wbot = w.index(bottom);
   int ny = pthermo_y->options->species().size() - 1;
 
-  auto target_w = wbot.clone();
-  auto target_x = pthermo_y->compute("Y->X", {target_w.narrow(0, ICY, ny)});
+  auto wbot = w.index(bottom);
+  auto rho = wbot[IDN];
+  auto current_y = wbot.narrow(0, ICY, ny);
+  auto target_x = pthermo_y->compute("Y->X", {current_y});
   for (int n = 0; n < species_ids.size(); ++n) {
     target_x.select(-1, species_ids[n]).fill_(options->xfrac()[n]);
   }
 
   auto dry = 1. - target_x.narrow(-1, 1, ny).sum(-1);
-  TORCH_CHECK(dry.min().item<double>() >= -1.e-12,
-              "[RelaxBotComp] Configured and retained species leave a "
-              "negative dry mole fraction.");
   target_x.select(-1, 0) = dry.clamp_min(0.);
 
   auto target_y = pthermo_x->compute("X->Y", {target_x});
-  target_w.narrow(0, ICY, ny) = target_y;
-  auto ivol = pthermo_y->compute("DY->V", {target_w[IDN], target_y});
-  target_w[IPR] = pthermo_y->compute("VT->P", {ivol, temp.index(bottom3)});
+  auto target_v = pthermo_y->compute("DY->V", {rho, target_y});
+  auto current_v = pthermo_y->compute("DY->V", {rho, current_y});
+  auto temp_bot = temp.index(bottom3);
+  auto target_ie = pthermo_y->compute("VT->U", {target_v, temp_bot});
+  auto current_ie = pthermo_y->compute("VT->U", {current_v, temp_bot});
 
-  auto target_u = phydro->peos->compute("W->U", {target_w});
-  auto current_u = phydro->peos->compute("W->U", {wbot});
-  du.index(bottom) += dt / options->tau() * (target_u - current_u);
+  auto delta = torch::zeros_like(wbot);
+  delta[IDN] = -rho * (target_y - current_y).sum(0);
+  delta.narrow(0, ICY, ny) = rho * (target_y - current_y);
+  delta[IPR] = target_ie - current_ie;
+  du.index(bottom) += dt / options->tau() * delta;
   return du;
 }
 

--- a/tests/test_forcing.cpp
+++ b/tests/test_forcing.cpp
@@ -15,9 +15,10 @@ using namespace snap;
 
 namespace {
 
-std::shared_ptr<MeshBlockImpl> make_block() {
+std::shared_ptr<MeshBlockImpl> make_block(
+    std::string const& filename = "test_diffusion_moist.yaml") {
   return std::make_shared<MeshBlockImpl>(
-      MeshBlockOptionsImpl::from_yaml("test_diffusion_moist.yaml"));
+      MeshBlockOptionsImpl::from_yaml(filename));
 }
 
 torch::Tensor make_primitive(std::shared_ptr<MeshBlockImpl> const& block) {
@@ -154,6 +155,19 @@ TEST(forcing, relax_bottom_composition_preserves_state) {
   EXPECT_TRUE(torch::allclose(
       block->phydro->peos->compute("W->T", {updated}).index(bot3),
       temp.index(bot3), 1.e-8, 1.e-8));
+  expect_only_bottom(du, block);
+}
+
+TEST(forcing, relax_bottom_composition_handles_multidimensional_ghost_zones) {
+  auto block = make_block("test_forcing_3d.yaml");
+  auto w = make_primitive(block);
+  auto temp = block->phydro->peos->compute("W->T", {w});
+  auto du = torch::zeros_like(w);
+  auto op = RelaxBotCompOptionsImpl::from_yaml(
+      YAML::Load("relax-bot-comp: {tau: 2., species: [vapor], xfrac: [0.2]}"));
+
+  RelaxBotComp(op, block->phydro.get())->forward(du, w, temp, 0.5);
+
   expect_only_bottom(du, block);
 }
 

--- a/tests/test_forcing_3d.yaml
+++ b/tests/test_forcing_3d.yaml
@@ -1,0 +1,39 @@
+reference-state:
+  Tref: 300.
+  Pref: 1.e5
+
+species:
+  - name: dry
+    composition: {O: 0.42, N: 1.56, Ar: 0.01}
+    cv_R: 2.5
+
+  - name: vapor
+    composition: {H: 2, O: 1}
+    cv_R: 3.5
+
+  - name: cloud
+    composition: {H: 2, O: 1}
+    cv_R: 9.0
+
+reactions:
+  - equation: vapor <=> cloud
+    type: nucleation
+    rate-constant: {formula: h2o_ideal}
+
+geometry:
+  type: cartesian
+  bounds: {x1min: 0., x1max: 6., x2min: 0., x2max: 4., x3min: 0., x3max: 3.}
+  cells: {nx1: 6, nx2: 4, nx3: 3, nghost: 2}
+
+dynamics:
+  equation-of-state:
+    type: ideal-moist
+
+boundary-condition:
+  external:
+    x1-inner: reflecting
+    x1-outer: reflecting
+    x2-inner: reflecting
+    x2-outer: reflecting
+    x3-inner: reflecting
+    x3-outer: reflecting


### PR DESCRIPTION
Avoid passing an interior-only bottom slice through EOS primitive-to-conserved conversion. That conversion lowers momentum with full-grid coordinate buffers, which caused shape mismatches whenever active horizontal dimensions included ghost zones.

- keep relax-bot-comp intermediates scoped to the single physical bottom layer
- convert current and target bottom compositions through Kintera ThermoY/ThermoX locally
- assemble dry-density, constituent-density, and internal-energy deltas directly at fixed temperature
- leave momentum unchanged so coordinate metric tensors are not needed
- add a 3D moist forcing fixture with ghost zones in every active direction
- add regression coverage proving bottom composition relaxation touches only the physical bottom layer without shape mismatches

Validated with:
- cmake --build build --target test_forcing.release -j8
- ctest --test-dir build -R '^test_forcing\.release$' --output-on-failure
- ctest --test-dir build -R '^(test_diffusion|test_diffusion_moist)\.release$' --output-on-failure
- git diff --check