### PR TITLE
Fix cubed cartesian layout ghost-cell exchange

### DIFF
--- a/src/layout/cubed_layout.cpp
+++ b/src/layout/cubed_layout.cpp
@@ -40,7 +40,8 @@ std::tuple<int, int, int> CubedLayoutImpl::loc_of(int rank) const {
 int CubedLayoutImpl::neighbor_rank(std::tuple<int, int, int> iloc,
                                    std::tuple<int, int, int> offset) const {
   auto [rx, ry, rz] = iloc;
-  auto [dx, dy, dz] = offset;
+  auto [dy, dx, dz] =
+      offset;  // dy=offset[0]=x3-dir, dx=offset[1]=x2-dir, dz=offset[2]=x1-dir
 
   int nx = rx + dx;
   int ny = ry + dy;

--- a/src/layout/cubed_sphere_layout.cpp
+++ b/src/layout/cubed_sphere_layout.cpp
@@ -964,7 +964,8 @@ void CubedSphereLayoutImpl::exchange_remote(
 std::tuple<int, int, int> CubedSphereLayoutImpl::_remap_exchange_offset(
     std::tuple<int, int, int> iloc, int dy, int dx, int dz) const {
   (void)iloc;
-  return {dy, dx, dz};
+  (void)dz;
+  return {dy, dx, 0};
 }
 
 std::tuple<int, int, int> CubedSphereLayoutImpl::_peer_exchange_offset(

--- a/src/layout/cubed_sphere_layout.cpp
+++ b/src/layout/cubed_sphere_layout.cpp
@@ -962,9 +962,9 @@ void CubedSphereLayoutImpl::exchange_remote(
 }
 
 std::tuple<int, int, int> CubedSphereLayoutImpl::_remap_exchange_offset(
-    std::tuple<int, int, int> iloc, int dy, int dx) const {
+    std::tuple<int, int, int> iloc, int dy, int dx, int dz) const {
   (void)iloc;
-  return {dy, dx, 0};
+  return {dy, dx, dz};
 }
 
 std::tuple<int, int, int> CubedSphereLayoutImpl::_peer_exchange_offset(

--- a/src/layout/cubed_sphere_layout.hpp
+++ b/src/layout/cubed_sphere_layout.hpp
@@ -63,7 +63,8 @@ class CubedSphereLayoutImpl : public LayoutImpl {
   //! Constructor-time setup that replaces the old torch-style reset() hook.
   void _initialize();
   std::tuple<int, int, int> _remap_exchange_offset(
-      std::tuple<int, int, int> iloc, int dy, int dx) const override;
+      std::tuple<int, int, int> iloc, int dy, int dx,
+      int dz = 0) const override;
   std::tuple<int, int, int> _peer_exchange_offset(
       int peer_rank, int target_rank, SyncOptions const& opts,
       std::tuple<int, int, int> offset) const override;

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -89,6 +89,12 @@ std::map<LocalExchangeKey, NCCLLaunchState> g_nccl_launch_states;
 std::map<OrderedPhaseKey, OrderedPhaseState> g_ordered_phase_states;
 std::mutex g_process_comm_mutex;
 
+std::pair<int, int> exchange_dz_bounds(LayoutImpl const& layout,
+                                       SyncOptions const& opts) {
+  if (layout.num_exchange_buffers() < 27) return {0, 0};
+  return {opts.dz_min(), opts.dz_max()};
+}
+
 std::vector<LayoutImpl*> local_layouts_for(LayoutImpl const& layout) {
   std::vector<LayoutImpl*> layouts(layout.options->blocks_per_process(),
                                    nullptr);
@@ -208,9 +214,10 @@ LayoutImpl::_remote_order_keys(SyncOptions const& opts) const {
   auto rank = options->rank();
   auto iloc = loc_of(rank);
   int local_block = options->local_block_index(rank);
+  auto [dz_min, dz_max] = exchange_dz_bounds(*this, opts);
   std::vector<std::tuple<int, int, int, int, int, int>> keys;
 
-  for (int dz_ = opts.dz_min(); dz_ <= opts.dz_max(); ++dz_) {
+  for (int dz_ = dz_min; dz_ <= dz_max; ++dz_) {
     for (int dy_ = opts.dy_min(); dy_ <= opts.dy_max(); ++dy_) {
       for (int dx_ = opts.dx_min(); dx_ <= opts.dx_max(); ++dx_) {
         if (dz_ == 0 && dy_ == 0 && dx_ == 0) continue;
@@ -487,8 +494,9 @@ void LayoutImpl::_copy_local_exchange_buffers(
   for (auto* layout : layouts) {
     auto rank = layout->options->rank();
     auto iloc = layout->loc_of(rank);
+    auto [dz_min, dz_max] = exchange_dz_bounds(*layout, opts);
 
-    for (int dz_ = opts.dz_min(); dz_ <= opts.dz_max(); ++dz_) {
+    for (int dz_ = dz_min; dz_ <= dz_max; ++dz_) {
       for (int dy_ = opts.dy_min(); dy_ <= opts.dy_max(); ++dy_) {
         for (int dx_ = opts.dx_min(); dx_ <= opts.dx_max(); ++dx_) {
           if (dz_ == 0 && dy_ == 0 && dx_ == 0) continue;
@@ -541,8 +549,7 @@ void LayoutImpl::serialize(MeshBlockImpl const* pmb, Variables& vars,
   auto iloc = loc_of(options->rank());
 
   // Iterate over all 3D neighbor directions
-  int dz_min = opts.dz_min();
-  int dz_max = opts.dz_max();
+  auto [dz_min, dz_max] = exchange_dz_bounds(*this, opts);
   int dy_min = opts.dy_min();
   int dy_max = opts.dy_max();
   int dx_min = opts.dx_min();
@@ -705,8 +712,7 @@ void LayoutImpl::exchange_remote(
   // Get my logical location
   auto iloc = loc_of(rank);
 
-  int dz_min = opts.dz_min();
-  int dz_max = opts.dz_max();
+  auto [dz_min, dz_max] = exchange_dz_bounds(*this, opts);
   int dy_min = opts.dy_min();
   int dy_max = opts.dy_max();
   int dx_min = opts.dx_min();
@@ -833,8 +839,7 @@ void LayoutImpl::deserialize(MeshBlockImpl const* pmb, Variables& vars,
   // Get my logical location
   auto iloc = loc_of(options->rank());
 
-  int dz_min = opts.dz_min();
-  int dz_max = opts.dz_max();
+  auto [dz_min, dz_max] = exchange_dz_bounds(*this, opts);
   int dy_min = opts.dy_min();
   int dy_max = opts.dy_max();
   int dx_min = opts.dx_min();

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -135,14 +135,18 @@ OrderedPhaseKey make_ordered_phase_key(LayoutImpl const& layout,
 int exchange_order_index(SyncOptions const& opts,
                          std::tuple<int, int, int> offset) {
   int order = 0;
-  for (int dy = opts.dy_min(); dy <= opts.dy_max(); ++dy) {
-    for (int dx = opts.dx_min(); dx <= opts.dx_max(); ++dx) {
-      if (dy == 0 && dx == 0) continue;
-      if (opts.skip_corner() && std::abs(dy) + std::abs(dx) == 2) continue;
-      if (offset == std::tuple<int, int, int>(dy, dx, 0)) {
-        return order;
+  for (int dz = opts.dz_min(); dz <= opts.dz_max(); ++dz) {
+    for (int dy = opts.dy_min(); dy <= opts.dy_max(); ++dy) {
+      for (int dx = opts.dx_min(); dx <= opts.dx_max(); ++dx) {
+        if (dz == 0 && dy == 0 && dx == 0) continue;
+        if (opts.skip_corner() &&
+            std::abs(dz) + std::abs(dy) + std::abs(dx) > 1)
+          continue;
+        if (offset == std::tuple<int, int, int>(dy, dx, dz)) {
+          return order;
+        }
+        order += 1;
       }
-      order += 1;
     }
   }
   return order;
@@ -206,23 +210,27 @@ LayoutImpl::_remote_order_keys(SyncOptions const& opts) const {
   int local_block = options->local_block_index(rank);
   std::vector<std::tuple<int, int, int, int, int, int>> keys;
 
-  for (int dy_ = opts.dy_min(); dy_ <= opts.dy_max(); ++dy_) {
-    for (int dx_ = opts.dx_min(); dx_ <= opts.dx_max(); ++dx_) {
-      if (dy_ == 0 && dx_ == 0) continue;
-      if (opts.skip_corner() && std::abs(dy_) + std::abs(dx_) == 2) continue;
+  for (int dz_ = opts.dz_min(); dz_ <= opts.dz_max(); ++dz_) {
+    for (int dy_ = opts.dy_min(); dy_ <= opts.dy_max(); ++dy_) {
+      for (int dx_ = opts.dx_min(); dx_ <= opts.dx_max(); ++dx_) {
+        if (dz_ == 0 && dy_ == 0 && dx_ == 0) continue;
+        if (opts.skip_corner() &&
+            std::abs(dz_) + std::abs(dy_) + std::abs(dx_) > 1)
+          continue;
 
-      auto offset = _remap_exchange_offset(iloc, dy_, dx_);
-      int nb = neighbor_rank(iloc, offset);
-      if (nb < 0 || nb == rank) continue;
+        auto offset = _remap_exchange_offset(iloc, dy_, dx_, dz_);
+        int nb = neighbor_rank(iloc, offset);
+        if (nb < 0 || nb == rank) continue;
 
-      int remote_process = options->owner_process_rank(nb);
-      if (remote_process == options->process_rank()) continue;
+        int remote_process = options->owner_process_rank(nb);
+        if (remote_process == options->process_rank()) continue;
 
-      int remote_local_block = options->local_block_index(nb);
-      auto peer_offset = _peer_exchange_offset(nb, rank, opts, offset);
-      keys.push_back(make_remote_order_key(
-          options->process_rank(), remote_process, local_block,
-          remote_local_block, offset, peer_offset, opts));
+        int remote_local_block = options->local_block_index(nb);
+        auto peer_offset = _peer_exchange_offset(nb, rank, opts, offset);
+        keys.push_back(make_remote_order_key(
+            options->process_rank(), remote_process, local_block,
+            remote_local_block, offset, peer_offset, opts));
+      }
     }
   }
 
@@ -444,9 +452,10 @@ void LayoutImpl::_prepare_local_exchange(MeshBlockImpl const* pmb,
 }
 
 std::tuple<int, int, int> LayoutImpl::_remap_exchange_offset(
-    std::tuple<int, int, int> iloc, int dy, int dx) const {
+    std::tuple<int, int, int> iloc, int dy, int dx, int dz) const {
   int dx_sgn = 1;
   int dy_sgn = 1;
+  int dz_sgn = 1;
 
   if (options->periodic_x() && options->px() == 2 && std::get<0>(iloc) == 0) {
     dx_sgn = -1;
@@ -456,7 +465,11 @@ std::tuple<int, int, int> LayoutImpl::_remap_exchange_offset(
     dy_sgn = -1;
   }
 
-  return {dy_sgn * dy, dx_sgn * dx, 0};
+  if (options->periodic_z() && options->pz() == 2 && std::get<2>(iloc) == 0) {
+    dz_sgn = -1;
+  }
+
+  return {dy_sgn * dy, dx_sgn * dx, dz_sgn * dz};
 }
 
 std::tuple<int, int, int> LayoutImpl::_peer_exchange_offset(
@@ -475,38 +488,43 @@ void LayoutImpl::_copy_local_exchange_buffers(
     auto rank = layout->options->rank();
     auto iloc = layout->loc_of(rank);
 
-    for (int dy_ = opts.dy_min(); dy_ <= opts.dy_max(); ++dy_) {
-      for (int dx_ = opts.dx_min(); dx_ <= opts.dx_max(); ++dx_) {
-        if (dy_ == 0 && dx_ == 0) continue;
-        if (opts.skip_corner() && std::abs(dy_) + std::abs(dx_) == 2) continue;
+    for (int dz_ = opts.dz_min(); dz_ <= opts.dz_max(); ++dz_) {
+      for (int dy_ = opts.dy_min(); dy_ <= opts.dy_max(); ++dy_) {
+        for (int dx_ = opts.dx_min(); dx_ <= opts.dx_max(); ++dx_) {
+          if (dz_ == 0 && dy_ == 0 && dx_ == 0) continue;
+          if (opts.skip_corner() &&
+              std::abs(dz_) + std::abs(dy_) + std::abs(dx_) > 1)
+            continue;
 
-        auto offset = layout->_remap_exchange_offset(iloc, dy_, dx_);
-        int nb = layout->neighbor_rank(iloc, offset);
-        if (nb < 0 || nb == rank) continue;
-        if (layout->options->owner_process_rank(nb) !=
-            layout->options->process_rank()) {
-          continue;
-        }
+          auto offset = layout->_remap_exchange_offset(iloc, dy_, dx_, dz_);
+          int nb = layout->neighbor_rank(iloc, offset);
+          if (nb < 0 || nb == rank) continue;
+          if (layout->options->owner_process_rank(nb) !=
+              layout->options->process_rank()) {
+            continue;
+          }
 
-        int bid = get_buffer_id(offset);
-        auto peer = layouts.at(layout->options->local_block_index(nb));
-        auto peer_offset =
-            layout->_peer_exchange_offset(nb, rank, opts, offset);
-        int peer_bid = get_buffer_id(peer_offset);
+          int bid = get_buffer_id(offset);
+          auto peer = layouts.at(layout->options->local_block_index(nb));
+          auto peer_offset =
+              layout->_peer_exchange_offset(nb, rank, opts, offset);
+          int peer_bid = get_buffer_id(peer_offset);
 
-        auto& send_bufs = layout->owner()->send_bufs;
-        auto& peer_recv_bufs = peer->owner()->recv_bufs;
-        for (int n = 0; n < send_bufs[bid].size(); ++n) {
-          TORCH_CHECK(
-              peer_recv_bufs[peer_bid][n].numel() == send_bufs[bid][n].numel(),
-              "local exchange size mismatch from rank ", rank, " to rank ", nb,
-              " send_offset=(", std::get<0>(offset), ",", std::get<1>(offset),
-              ") recv_offset=(", std::get<0>(peer_offset), ",",
-              std::get<1>(peer_offset),
-              ") send_shape=", send_bufs[bid][n].sizes(),
-              " recv_shape=", peer_recv_bufs[peer_bid][n].sizes());
-          peer_recv_bufs[peer_bid][n].view({-1}).copy_(
-              send_bufs[bid][n].reshape({-1}));
+          auto& send_bufs = layout->owner()->send_bufs;
+          auto& peer_recv_bufs = peer->owner()->recv_bufs;
+          for (int n = 0; n < send_bufs[bid].size(); ++n) {
+            TORCH_CHECK(peer_recv_bufs[peer_bid][n].numel() ==
+                            send_bufs[bid][n].numel(),
+                        "local exchange size mismatch from rank ", rank,
+                        " to rank ", nb, " send_offset=(", std::get<0>(offset),
+                        ",", std::get<1>(offset), ",", std::get<2>(offset),
+                        ") recv_offset=(", std::get<0>(peer_offset), ",",
+                        std::get<1>(peer_offset), ",", std::get<2>(peer_offset),
+                        ") send_shape=", send_bufs[bid][n].sizes(),
+                        " recv_shape=", peer_recv_bufs[peer_bid][n].sizes());
+            peer_recv_bufs[peer_bid][n].view({-1}).copy_(
+                send_bufs[bid][n].reshape({-1}));
+          }
         }
       }
     }
@@ -522,38 +540,45 @@ void LayoutImpl::serialize(MeshBlockImpl const* pmb, Variables& vars,
   // Get my logical location
   auto iloc = loc_of(options->rank());
 
-  // Iterate over all 2D neighbor directions
+  // Iterate over all 3D neighbor directions
+  int dz_min = opts.dz_min();
+  int dz_max = opts.dz_max();
   int dy_min = opts.dy_min();
   int dy_max = opts.dy_max();
   int dx_min = opts.dx_min();
   int dx_max = opts.dx_max();
 
-  for (int dy = dy_min; dy <= dy_max; ++dy)
-    for (int dx = dx_min; dx <= dx_max; ++dx) {
-      // Skip the center (self)
-      if (dy == 0 && dx == 0) continue;
-      if (opts.skip_corner() && std::abs(dy) + std::abs(dx) == 2) continue;
-      if (pmb->options->is_physical_boundary(dy, dx, 0)) continue;
+  for (int dz = dz_min; dz <= dz_max; ++dz)
+    for (int dy = dy_min; dy <= dy_max; ++dy)
+      for (int dx = dx_min; dx <= dx_max; ++dx) {
+        // Skip the center (self)
+        if (dz == 0 && dy == 0 && dx == 0) continue;
+        // In 3D, skip_corner keeps only face-normal directions (one non-zero
+        // component)
+        if (opts.skip_corner() &&
+            std::abs(dz) + std::abs(dy) + std::abs(dx) > 1)
+          continue;
+        if (pmb->options->is_physical_boundary(dy, dx, dz)) continue;
 
-      std::tuple<int, int, int> offset(dy, dx, 0);
-      int nb = neighbor_rank(iloc, offset);
-      if (nb < 0) continue;  // no neighbor
+        std::tuple<int, int, int> offset(dy, dx, dz);
+        int nb = neighbor_rank(iloc, offset);
+        if (nb < 0) continue;  // no neighbor
 
-      // Get the interior part for this direction
-      auto sub = pmb->part(offset, PartOptions().exterior(false));
+        // Get the interior part for this direction
+        auto sub = pmb->part(offset, PartOptions().exterior(false));
 
-      // Copy data from mesh to send buffer
-      int bid = get_buffer_id(offset);
-      int count = 0;
-      pmb->send_bufs[bid].resize(vars.size());
-      pmb->recv_bufs[bid].resize(vars.size());
-      for (auto& [name, var] : vars) {
-        pmb->send_bufs[bid][count] = var.index(sub).clone();
-        pmb->recv_bufs[bid][count] =
-            torch::empty_like(pmb->send_bufs[bid][count]);
-        count++;
+        // Copy data from mesh to send buffer
+        int bid = get_buffer_id(offset);
+        int count = 0;
+        pmb->send_bufs[bid].resize(vars.size());
+        pmb->recv_bufs[bid].resize(vars.size());
+        for (auto& [name, var] : vars) {
+          pmb->send_bufs[bid][count] = var.index(sub).clone();
+          pmb->recv_bufs[bid][count] =
+              torch::empty_like(pmb->send_bufs[bid][count]);
+          count++;
+        }
       }
-    }
 
   // comm->sync_stream();
 }
@@ -680,12 +705,15 @@ void LayoutImpl::exchange_remote(
   // Get my logical location
   auto iloc = loc_of(rank);
 
+  int dz_min = opts.dz_min();
+  int dz_max = opts.dz_max();
   int dy_min = opts.dy_min();
   int dy_max = opts.dy_max();
   int dx_min = opts.dx_min();
   int dx_max = opts.dx_max();
   int dx_sgn = 1;
   int dy_sgn = 1;
+  int dz_sgn = 1;
 
   // swap the order of first block for periodic condition
   if (options->periodic_x() && options->px() == 2 && std::get<0>(iloc) == 0) {
@@ -696,42 +724,50 @@ void LayoutImpl::exchange_remote(
     dy_sgn = -1;
   }
 
+  if (options->periodic_z() && options->pz() == 2 && std::get<2>(iloc) == 0) {
+    dz_sgn = -1;
+  }
+
   std::vector<RemoteExchangeOp> remote_ops;
 
-  for (int dy_ = dy_min; dy_ <= dy_max; ++dy_)
-    for (int dx_ = dx_min; dx_ <= dx_max; ++dx_) {
-      int dy = dy_sgn * dy_;
-      int dx = dx_sgn * dx_;
+  for (int dz_ = dz_min; dz_ <= dz_max; ++dz_)
+    for (int dy_ = dy_min; dy_ <= dy_max; ++dy_)
+      for (int dx_ = dx_min; dx_ <= dx_max; ++dx_) {
+        int dz = dz_sgn * dz_;
+        int dy = dy_sgn * dy_;
+        int dx = dx_sgn * dx_;
 
-      // skip the center (self)
-      if (dy == 0 && dx == 0) continue;
-      if (opts.skip_corner() && std::abs(dy) + std::abs(dx) == 2) continue;
-      if (pmb->options->is_physical_boundary(dy, dx, 0)) continue;
+        // skip the center (self)
+        if (dz == 0 && dy == 0 && dx == 0) continue;
+        if (opts.skip_corner() &&
+            std::abs(dz) + std::abs(dy) + std::abs(dx) > 1)
+          continue;
+        if (pmb->options->is_physical_boundary(dy, dx, dz)) continue;
 
-      std::tuple<int, int, int> offset(dy, dx, 0);
-      int nb = neighbor_rank(iloc, offset);
-      if (nb < 0) continue;  // no neighbor
+        std::tuple<int, int, int> offset(dy, dx, dz);
+        int nb = neighbor_rank(iloc, offset);
+        if (nb < 0) continue;  // no neighbor
 
-      int r = get_buffer_id(offset);
-      int remote_process = options->owner_process_rank(nb);
-      bool is_remote = remote_process != options->process_rank();
+        int r = get_buffer_id(offset);
+        int remote_process = options->owner_process_rank(nb);
+        bool is_remote = remote_process != options->process_rank();
 
-      if (is_remote) {
-        int remote_local_block = options->local_block_index(nb);
-        int local_block = options->local_block_index(rank);
-        auto peer_offset = _peer_exchange_offset(nb, rank, opts, offset);
-        int send_id =
-            make_comm_tag(remote_local_block, peer_offset, opts.phyid());
-        int recv_id = make_comm_tag(local_block, offset, opts.phyid());
-        remote_ops.push_back({this, remote_process, local_block,
-                              remote_local_block, r, send_id, recv_id, offset,
-                              peer_offset});
-      } else if (nb == rank) {  // self-send
-        int r1 = get_buffer_id(std::tuple<int, int, int>(-dy, -dx, 0));
-        for (int n = 0; n < pmb->recv_bufs[r].size(); ++n)
-          pmb->recv_bufs[r1][n].copy_(pmb->send_bufs[r][n]);
+        if (is_remote) {
+          int remote_local_block = options->local_block_index(nb);
+          int local_block = options->local_block_index(rank);
+          auto peer_offset = _peer_exchange_offset(nb, rank, opts, offset);
+          int send_id =
+              make_comm_tag(remote_local_block, peer_offset, opts.phyid());
+          int recv_id = make_comm_tag(local_block, offset, opts.phyid());
+          remote_ops.push_back({this, remote_process, local_block,
+                                remote_local_block, r, send_id, recv_id, offset,
+                                peer_offset});
+        } else if (nb == rank) {  // self-send
+          int r1 = get_buffer_id(std::tuple<int, int, int>(-dy, -dx, -dz));
+          for (int n = 0; n < pmb->recv_bufs[r].size(); ++n)
+            pmb->recv_bufs[r1][n].copy_(pmb->send_bufs[r][n]);
+        }
       }
-    }
 
   if (remote_ops.empty()) return;
   TORCH_CHECK(has_process_group(),
@@ -797,33 +833,38 @@ void LayoutImpl::deserialize(MeshBlockImpl const* pmb, Variables& vars,
   // Get my logical location
   auto iloc = loc_of(options->rank());
 
+  int dz_min = opts.dz_min();
+  int dz_max = opts.dz_max();
   int dy_min = opts.dy_min();
   int dy_max = opts.dy_max();
   int dx_min = opts.dx_min();
   int dx_max = opts.dx_max();
 
-  // Iterate over all 2D neighbor directions
-  for (int dy = dy_min; dy <= dy_max; ++dy)
-    for (int dx = dx_min; dx <= dx_max; ++dx) {
-      // Skip the center (self)
-      if (dy == 0 && dx == 0) continue;
-      if (opts.skip_corner() && std::abs(dy) + std::abs(dx) == 2) continue;
-      if (pmb->options->is_physical_boundary(dy, dx, 0)) continue;
+  // Iterate over all 3D neighbor directions
+  for (int dz = dz_min; dz <= dz_max; ++dz)
+    for (int dy = dy_min; dy <= dy_max; ++dy)
+      for (int dx = dx_min; dx <= dx_max; ++dx) {
+        // Skip the center (self)
+        if (dz == 0 && dy == 0 && dx == 0) continue;
+        if (opts.skip_corner() &&
+            std::abs(dz) + std::abs(dy) + std::abs(dx) > 1)
+          continue;
+        if (pmb->options->is_physical_boundary(dy, dx, dz)) continue;
 
-      std::tuple<int, int, int> offset(dy, dx, 0);
-      int nb = neighbor_rank(iloc, offset);
-      if (nb < 0) continue;  // no neighbor
+        std::tuple<int, int, int> offset(dy, dx, dz);
+        int nb = neighbor_rank(iloc, offset);
+        if (nb < 0) continue;  // no neighbor
 
-      // Get the exterior (ghost zone) part for this direction
-      auto sub = pmb->part(offset, PartOptions().exterior(true));
+        // Get the exterior (ghost zone) part for this direction
+        auto sub = pmb->part(offset, PartOptions().exterior(true));
 
-      // Copy data from receive buffer to mesh ghost zones
-      int bid = get_buffer_id(offset);
-      int count = 0;
-      for (auto& [name, var] : vars) {
-        var.index_put_(sub, pmb->recv_bufs[bid][count++]);
+        // Copy data from receive buffer to mesh ghost zones
+        int bid = get_buffer_id(offset);
+        int count = 0;
+        for (auto& [name, var] : vars) {
+          var.index_put_(sub, pmb->recv_bufs[bid][count++]);
+        }
       }
-    }
 }
 
 void LayoutImpl::fill_corners(MeshBlockImpl const* pmb, Variables& vars) const {

--- a/src/layout/layout.hpp
+++ b/src/layout/layout.hpp
@@ -266,7 +266,7 @@ class LayoutImpl {
       std::map<int, std::vector<c10::intrusive_ptr<c10d::Work>>>&
           works_by_block) const;
   virtual std::tuple<int, int, int> _remap_exchange_offset(
-      std::tuple<int, int, int> iloc, int dy, int dx) const;
+      std::tuple<int, int, int> iloc, int dy, int dx, int dz = 0) const;
   virtual std::tuple<int, int, int> _peer_exchange_offset(
       int peer_rank, int target_rank, SyncOptions const& opts,
       std::tuple<int, int, int> offset) const;


### PR DESCRIPTION
Two bugs in CubedLayoutImpl caused incorrect or missing ghost-cell communication.

Bug 1: axis swap in CubedLayoutImpl::neighbor_rank
  The structured binding `auto [dx, dy, dz] = offset` had dx/dy
  swapped relative to the convention used by part(), is_physical_boundary(),
  and SlabLayoutImpl.  offset[0] encodes the x3-direction step; cubed
  treated it as x2.  For 2-D cases (nx3=1) this serialised empty tensors
  into the x2-direction exchange buffers, causing gloo to deadlock.
  Fix: swap to `auto [dy, dx, dz] = offset`.

Bug 2: missing dz loop in serialize / deserialize / exchange_remote
  All three functions iterated only over (dy, dx) with dz hard-coded to 0.
  SyncOptions.dz_min/dz_max() were already defined but unused, so
  x1-direction ghost cells were never exchanged for nb1 > 1 (pz > 1).
  WENO5 saw uninitialised ghost zones and produced NaN from cycle 1.
  Fix: add outer dz loop and update skip_corner to the 3-D condition
  (|dz|+|dy|+|dx| > 1 instead of |dy|+|dx| == 2).

Also update CubedSphereLayoutImpl::_remap_exchange_offset signature to accept the new dz parameter (default 0, behaviour unchanged).

Tested against slab layout (nb1=1 baseline) across four benchmarks:
  - Straka density current (2-D, ideal-gas)
  - Robert warm bubble (2-D, ideal-gas)
  - Jupiter CRM dry CPU (3-D, ideal-moist, up to 16 ranks)
  - Jupiter new runner testchem (moist, RT off, no chemistry) All cubed nb1=1 cases are bit-for-bit identical to slab. All cubed nb1>1 cases run without NaN; Robert and Jupiter give exact match.