### PR TITLE
Use spherical velocity frame for cubed-sphere exchange

### DIFF
--- a/python/csrc/pycoord.cpp
+++ b/python/csrc/pycoord.cpp
@@ -117,6 +117,8 @@ void bind_coord(py::module &m) {
       .def("coord_vec_raise_", &snap::coord_vec_raise_)
       .def("cs_cart_to_contra_", &snap::cs_cart_to_contra_)
       .def("cs_contra_to_cart_", &snap::cs_contra_to_cart_)
+      .def("cs_sph_to_contra_", &snap::cs_sph_to_contra_)
+      .def("cs_contra_to_sph_", &snap::cs_contra_to_sph_)
       .def("cs_ab_to_lonlat", &snap::cs_ab_to_lonlat)
       .def("get_cs_face_name", [](int face_id) {
         return std::string(snap::CS_FACE_NAMES[face_id]);

--- a/python/snapy/coordinate.pyi
+++ b/python/snapy/coordinate.pyi
@@ -289,6 +289,16 @@ class coord:
         ...
 
     @staticmethod
+    def cs_sph_to_contra_(*args) -> None:
+        """Convert spherical polar to contravariant coordinates on cubed sphere."""
+        ...
+
+    @staticmethod
+    def cs_contra_to_sph_(*args) -> None:
+        """Convert contravariant to spherical polar coordinates on cubed sphere."""
+        ...
+
+    @staticmethod
     def cs_ab_to_lonlat(*args) -> Tuple[float, float]:
         """
         Convert cubed sphere (a, b) coordinates to longitude/latitude.

--- a/src/coord/cubed_sphere_utils.cpp
+++ b/src/coord/cubed_sphere_utils.cpp
@@ -11,6 +11,7 @@
 #include <snap/mesh/meshblock.hpp>
 
 #include "cubed_sphere_utils.hpp"
+#include "spherical_utils.hpp"
 
 namespace snap {
 
@@ -140,6 +141,54 @@ std::pair<torch::Tensor, torch::Tensor> cs_ab_to_lonlat(char const *face,
   return {lon, lat};
 }
 
+static std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+cs_ab_to_xyz_tensors(char const *face, torch::Tensor const &alpha,
+                     torch::Tensor const &beta) {
+  auto a = alpha.tan();
+  auto b = beta.tan();
+  auto one = torch::ones_like(a);
+
+  torch::Tensor x, y, z;
+  if (strcmp(face, "+X") == 0) {
+    x = one;
+    y = a;
+    z = b;
+  } else if (strcmp(face, "+Y") == 0) {
+    x = -a;
+    y = one;
+    z = b;
+  } else if (strcmp(face, "-X") == 0) {
+    x = -one;
+    y = -a;
+    z = b;
+  } else if (strcmp(face, "+Z") == 0) {
+    x = -b;
+    y = a;
+    z = one;
+  } else if (strcmp(face, "-Y") == 0) {
+    x = a;
+    y = -one;
+    z = b;
+  } else if (strcmp(face, "-Z") == 0) {
+    x = b;
+    y = a;
+    z = -one;
+  } else {
+    TORCH_CHECK(false, "invalid cubed-sphere face name: ", face);
+  }
+
+  auto r = (x * x + y * y + z * z).sqrt();
+  return {x / r, y / r, z / r};
+}
+
+static std::pair<torch::Tensor, torch::Tensor> cs_ab_to_theta_phi(
+    torch::Tensor const &alpha, torch::Tensor const &beta, int face_id) {
+  auto [x, y, z] = cs_ab_to_xyz_tensors(CS_FACE_NAMES[face_id], alpha, beta);
+  auto theta = z.clamp(-1.0, 1.0).acos();
+  auto phi = torch::atan2(y, x);
+  return {theta, phi};
+}
+
 //! Transform global cartesian velocity to local panel contravariant velocity
 void cs_cart_to_contra_(torch::Tensor const &vel, torch::Tensor alpha,
                         torch::Tensor beta, int face_id) {
@@ -152,7 +201,7 @@ void cs_cart_to_contra_(torch::Tensor const &vel, torch::Tensor alpha,
 
   std::array<torch::Tensor, 3> local_vel;
 
-  auto const g2l = CS_G2L_VEL;
+  auto const g2l = CS_CART_TO_LOCAL_VEL;
   auto f = face_id;
 
   local_vel[g2l[f][VEL1].idx] = g2l[f][VEL1].sgn * vel[VEL1];
@@ -177,7 +226,7 @@ void cs_contra_to_cart_(torch::Tensor const &vel, torch::Tensor alpha,
   auto C = sqrt(1 + x * x);
   auto D = sqrt(1 + y * y);
 
-  auto const l2g = CS_L2G_VEL;
+  auto const l2g = CS_LOCAL_TO_CART_VEL;
   auto f = face_id;
 
   auto vz = vel[VEL1].clone();
@@ -190,6 +239,20 @@ void cs_contra_to_cart_(torch::Tensor const &vel, torch::Tensor alpha,
       l2g[f][VEL2].sgn * (vz * x + vx * D - (vy * x * y) / C) / delta;
   vel[l2g[f][VEL3].idx] =
       l2g[f][VEL3].sgn * (vz * y + vy * C - (vx * x * y) / D) / delta;
+}
+
+void cs_contra_to_sph_(torch::Tensor const &vel, torch::Tensor alpha,
+                       torch::Tensor beta, int face_id) {
+  auto [theta, phi] = cs_ab_to_theta_phi(alpha, beta, face_id);
+  cs_contra_to_cart_(vel, alpha, beta, face_id);
+  sph_cart_to_contra_(vel, theta, phi);
+}
+
+void cs_sph_to_contra_(torch::Tensor const &vel, torch::Tensor alpha,
+                       torch::Tensor beta, int face_id) {
+  auto [theta, phi] = cs_ab_to_theta_phi(alpha, beta, face_id);
+  sph_contra_to_cart_(vel, theta, phi);
+  cs_cart_to_contra_(vel, alpha, beta, face_id);
 }
 
 }  // namespace snap

--- a/src/coord/cubed_sphere_utils.hpp
+++ b/src/coord/cubed_sphere_utils.hpp
@@ -169,4 +169,20 @@ void cs_cart_to_contra_(torch::Tensor const &vel, torch::Tensor alpha,
 void cs_contra_to_cart_(torch::Tensor const &vel, torch::Tensor alpha,
                         torch::Tensor beta, int face_id);
 
+//! \brief Transform contravariant velocities to global spherical polar velocity
+/*!
+ * The spherical polar basis is defined by the global cartesian position on the
+ * unit sphere, with components ordered as (v_r, v_theta, v_phi).
+ */
+void cs_contra_to_sph_(torch::Tensor const &vel, torch::Tensor alpha,
+                       torch::Tensor beta, int face_id);
+
+//! \brief Transform global spherical polar velocity to contravariant velocities
+/*!
+ * The spherical polar basis is defined by the global cartesian position on the
+ * unit sphere, with components ordered as (v_r, v_theta, v_phi).
+ */
+void cs_sph_to_contra_(torch::Tensor const &vel, torch::Tensor alpha,
+                       torch::Tensor beta, int face_id);
+
 }  // namespace snap

--- a/src/layout/cubed_sphere_layout.cpp
+++ b/src/layout/cubed_sphere_layout.cpp
@@ -220,7 +220,7 @@ const char CS_FACE_NAMES[6][3] = {"+X", "+Y", "-X", "+Z", "-Y", "-Z"};
  * Each entry says: on face F, the global velocity component VEL{1,2,3}
  * corresponds to local component idx with sign sgn.
  */
-const CSVel CS_G2L_VEL[6][3] = {
+const CSVel CS_CART_TO_LOCAL_VEL[6][3] = {
     /* face 0: */
     [0] = {/* VEL1 */ {VEL3, +1},
            /* VEL2 */ {VEL1, +1},
@@ -250,6 +250,58 @@ const CSVel CS_G2L_VEL[6][3] = {
  * Each entry says: on face F, the local velocity component VEL_{Z,X,Y}
  * corresponds to global component idx with sign sgn.
  */
+const CSVel CS_LOCAL_TO_CART_VEL[6][3] = {
+    /* face 0: */
+    [0] = {/* VEL1 */ {VEL2, +1},
+           /* VEL2 */ {VEL3, +1},
+           /* VEL3 */ {VEL1, +1}},
+    /* face 1: */
+    [1] = {/* VEL1 */ {VEL3, +1},
+           /* VEL2 */ {VEL2, -1},
+           /* VEL3 */ {VEL1, +1}},
+    /* face 2: */
+    [2] = {/* VEL1 */ {VEL2, -1},
+           /* VEL2 */ {VEL3, -1},
+           /* VEL3 */ {VEL1, +1}},
+    /* face 3: */
+    [3] = {/* VEL1 */ {VEL1, +1},
+           /* VEL2 */ {VEL3, +1},
+           /* VEL3 */ {VEL2, -1}},
+    /* face 4: */
+    [4] = {/* VEL1 */ {VEL3, -1},
+           /* VEL2 */ {VEL2, +1},
+           /* VEL3 */ {VEL1, +1}},
+    /* face 5: */
+    [5] = {/* VEL1 */ {VEL1, -1},
+           /* VEL2 */ {VEL3, +1},
+           /* VEL3 */ {VEL2, +1}}};
+
+const CSVel CS_G2L_VEL[6][3] = {
+    /* face 0: */
+    [0] = {/* VEL1 */ {VEL3, +1},
+           /* VEL2 */ {VEL1, +1},
+           /* VEL3 */ {VEL2, +1}},
+    /* face 1: */
+    [1] = {/* VEL1 */ {VEL3, +1},
+           /* VEL2 */ {VEL2, -1},
+           /* VEL3 */ {VEL1, +1}},
+    /* face 2: */
+    [2] = {/* VEL1 */ {VEL3, +1},
+           /* VEL2 */ {VEL1, -1},
+           /* VEL3 */ {VEL2, -1}},
+    /* face 3: */
+    [3] = {/* VEL1 */ {VEL1, +1},
+           /* VEL2 */ {VEL3, -1},
+           /* VEL3 */ {VEL2, +1}},
+    /* face 4: */
+    [4] = {/* VEL1 */ {VEL3, +1},
+           /* VEL2 */ {VEL2, +1},
+           /* VEL3 */ {VEL1, -1}},
+    /* face 5: */
+    [5] = {/* VEL1 */ {VEL1, -1},
+           /* VEL2 */ {VEL3, +1},
+           /* VEL3 */ {VEL2, +1}}};
+
 const CSVel CS_L2G_VEL[6][3] = {
     /* face 0: */
     [0] = {/* VEL1 */ {VEL2, +1},
@@ -661,11 +713,11 @@ void CubedSphereLayoutImpl::serialize(MeshBlockImpl const* pmb, Variables& vars,
           case kConserved: {
             auto vel = var_send.narrow(0, IVX, 3);
             coord_vec_raise_(vel, cosine_cell.index(sub3));
-            cs_contra_to_cart_(vel, alpha, beta, std::get<2>(iloc));
+            cs_contra_to_sph_(vel, alpha, beta, std::get<2>(iloc));
           } break;
           case kPrimitive: {
             auto vel = var_send.narrow(0, IVX, 3);
-            cs_contra_to_cart_(vel, alpha, beta, std::get<2>(iloc));
+            cs_contra_to_sph_(vel, alpha, beta, std::get<2>(iloc));
           } break;
           case kScalar:
             break;
@@ -829,12 +881,12 @@ void CubedSphereLayoutImpl::deserialize(MeshBlockImpl const* pmb,
         switch (opts.type()) {
           case kConserved: {
             auto vel = var.index(sub).narrow(0, IVX, 3);
-            cs_cart_to_contra_(vel, alpha, beta, std::get<2>(iloc));
+            cs_sph_to_contra_(vel, alpha, beta, std::get<2>(iloc));
             coord_vec_lower_(vel, cosine_cell.index(sub3));
           } break;
           case kPrimitive: {
             auto vel = var.index(sub).narrow(0, IVX, 3);
-            cs_cart_to_contra_(vel, alpha, beta, std::get<2>(iloc));
+            cs_sph_to_contra_(vel, alpha, beta, std::get<2>(iloc));
           } break;
           case kScalar:
             break;

--- a/src/layout/cubed_sphere_layout.hpp
+++ b/src/layout/cubed_sphere_layout.hpp
@@ -20,6 +20,8 @@ struct CSVel {
 
 extern const char CS_FACE_NAMES[6][3];
 extern const CSEdge CS_FACE_EDGES[6][4];
+extern const CSVel CS_CART_TO_LOCAL_VEL[6][3];
+extern const CSVel CS_LOCAL_TO_CART_VEL[6][3];
 extern const CSVel CS_G2L_VEL[6][3];
 extern const CSVel CS_L2G_VEL[6][3];
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,16 @@ set_tests_properties(test_mesh_exchange_python PROPERTIES
   LABELS "python;exchange"
 )
 
+add_test(
+  NAME test_cubed_sphere_vertical_velocity_exchange_python
+  COMMAND ${Python3_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/test_cubed_sphere_vertical_velocity_exchange.py
+)
+set_tests_properties(test_cubed_sphere_vertical_velocity_exchange_python PROPERTIES
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests
+  LABELS "python;exchange;cubed-sphere;diagnostic"
+)
+
 file(GLOB inputs *.yaml *.py)
 # create tests folder if does not exist
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/tests/test_coordinate.cpp
+++ b/tests/test_coordinate.cpp
@@ -6,6 +6,7 @@
 #include <snap/coord/coordinate.hpp>
 #include <snap/coord/cubed_sphere_utils.hpp>
 #include <snap/coord/gnomonic_equiangle.hpp>
+#include <snap/coord/spherical_utils.hpp>
 #include <snap/layout/cubed_sphere_layout.hpp>
 #include <snap/mesh/meshblock.hpp>
 
@@ -87,6 +88,93 @@ TEST_P(DeviceTest, contra_cart) {
   cs_contra_to_cart_(vel, mesh[0], mesh[1], 0);
 
   EXPECT_TRUE(torch::allclose(vel, vel_cart));
+}
+
+TEST_P(DeviceTest, contra_sph) {
+  auto op = MeshBlockOptionsImpl::from_yaml("test_coordinate.yaml");
+  auto block = MeshBlock(op);
+  block->to(device, dtype);
+
+  auto pcoord = block->pcoord;
+  int nc1 = pcoord->options->nc1();
+  int nc2 = pcoord->options->nc2();
+  int nc3 = pcoord->options->nc3();
+
+  auto opts = torch::TensorOptions().dtype(dtype).device(device);
+  auto mesh = torch::meshgrid({pcoord->x3v, pcoord->x2v, pcoord->x1v}, "ij");
+  auto alpha = mesh[1];
+  auto beta = mesh[0];
+
+  auto vel_contra = torch::randn({3, nc3, nc2, nc1}, opts) +
+                    torch::full({3, nc3, nc2, nc1}, 0.5, opts);
+
+  for (int face = 0; face < 6; ++face) {
+    auto vel = vel_contra.clone();
+    cs_contra_to_sph_(vel, alpha, beta, face);
+    cs_sph_to_contra_(vel, alpha, beta, face);
+    EXPECT_TRUE(torch::allclose(vel, vel_contra, 1.e-4, 1.e-5))
+        << "face " << face;
+  }
+}
+
+TEST_P(DeviceTest, contra_sph_matches_cartesian_composition) {
+  auto op = MeshBlockOptionsImpl::from_yaml("test_coordinate.yaml");
+  auto block = MeshBlock(op);
+  block->to(device, dtype);
+
+  auto pcoord = block->pcoord;
+  int nc1 = pcoord->options->nc1();
+  int nc2 = pcoord->options->nc2();
+  int nc3 = pcoord->options->nc3();
+
+  auto opts = torch::TensorOptions().dtype(dtype).device(device);
+  auto mesh = torch::meshgrid({pcoord->x3v, pcoord->x2v, pcoord->x1v}, "ij");
+  auto alpha = mesh[1];
+  auto beta = mesh[0];
+
+  auto vel_contra = torch::randn({3, nc3, nc2, nc1}, opts) +
+                    torch::full({3, nc3, nc2, nc1}, 0.5, opts);
+
+  for (int face = 0; face < 6; ++face) {
+    auto expected = vel_contra.clone();
+    cs_contra_to_cart_(expected, alpha, beta, face);
+    auto lonlat = cs_ab_to_lonlat(CS_FACE_NAMES[face], alpha, beta);
+    auto theta = 0.5 * M_PI - lonlat.second;
+    sph_cart_to_contra_(expected, theta, lonlat.first);
+
+    auto actual = vel_contra.clone();
+    cs_contra_to_sph_(actual, alpha, beta, face);
+
+    EXPECT_TRUE(torch::allclose(actual, expected, 1.e-4, 1.e-5))
+        << "face " << face;
+  }
+}
+
+TEST_P(DeviceTest, uniform_radial_spherical_velocity_round_trips) {
+  auto op = MeshBlockOptionsImpl::from_yaml("test_coordinate.yaml");
+  auto block = MeshBlock(op);
+  block->to(device, dtype);
+
+  auto pcoord = block->pcoord;
+  int nc1 = pcoord->options->nc1();
+  int nc2 = pcoord->options->nc2();
+  int nc3 = pcoord->options->nc3();
+
+  auto opts = torch::TensorOptions().dtype(dtype).device(device);
+  auto mesh = torch::meshgrid({pcoord->x3v, pcoord->x2v, pcoord->x1v}, "ij");
+  auto alpha = mesh[1];
+  auto beta = mesh[0];
+
+  auto vel_sph = torch::zeros({3, nc3, nc2, nc1}, opts);
+  vel_sph[VEL1].fill_(1.2345);
+
+  for (int face = 0; face < 6; ++face) {
+    auto vel = vel_sph.clone();
+    cs_sph_to_contra_(vel, alpha, beta, face);
+    cs_contra_to_sph_(vel, alpha, beta, face);
+    EXPECT_TRUE(torch::allclose(vel, vel_sph, 1.e-4, 1.e-5))
+        << "face " << face;
+  }
 }
 
 TEST_P(DeviceTest, usrc) {

--- a/tests/test_coordinate.cpp
+++ b/tests/test_coordinate.cpp
@@ -172,8 +172,7 @@ TEST_P(DeviceTest, uniform_radial_spherical_velocity_round_trips) {
     auto vel = vel_sph.clone();
     cs_sph_to_contra_(vel, alpha, beta, face);
     cs_contra_to_sph_(vel, alpha, beta, face);
-    EXPECT_TRUE(torch::allclose(vel, vel_sph, 1.e-4, 1.e-5))
-        << "face " << face;
+    EXPECT_TRUE(torch::allclose(vel, vel_sph, 1.e-4, 1.e-5)) << "face " << face;
   }
 }
 

--- a/tests/test_cubed_sphere_vertical_velocity_exchange.py
+++ b/tests/test_cubed_sphere_vertical_velocity_exchange.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+import torch
+import snapy
+
+
+VERTICAL_VELOCITY = 1.2345
+ABS_TOL = 1.0e-12
+REL_TOL = 1.0e-12
+HORIZONTAL_OFFSETS = (
+    (0, -1, 0),
+    (0, 1, 0),
+    (-1, 0, 0),
+    (1, 0, 0),
+)
+
+
+def make_mesh():
+    options = snapy.MeshOptions.from_yaml(
+        str(Path(__file__).with_name("test_exchange.yaml"))
+    )
+    options.blocks_per_process(6)
+    options.set_local_horizontal_cells(6, 6)
+    return snapy.Mesh(options)
+
+
+def make_uniform_vertical_velocity_state(mesh):
+    variables = []
+
+    for block in mesh.blocks:
+        coord = block.options.coord()
+        eos = block.module("hydro.eos")
+        nvar = eos.nvar()
+        shape = (
+            nvar,
+            coord.nx3() + 2 * coord.nghost(),
+            coord.nx2() + 2 * coord.nghost(),
+            coord.nx1(),
+        )
+        hydro_w = torch.full(shape, -999.0, dtype=torch.float64)
+        interior = block.part((0, 0, 0), False)
+        interior_cells = interior[1:]
+
+        hydro_w[snapy.kIDN][interior_cells] = 1.0
+        hydro_w[snapy.kIV1][interior_cells] = VERTICAL_VELOCITY
+        hydro_w[snapy.kIV2][interior_cells] = 0.0
+        hydro_w[snapy.kIV3][interior_cells] = 0.0
+        hydro_w[snapy.kIPR][interior_cells] = 1.0e5
+
+        variables.append({"hydro_w": hydro_w})
+
+    return variables
+
+
+def gather_vertical_velocity_ghost_values(block, block_vars):
+    values = []
+    for offset in HORIZONTAL_OFFSETS:
+        ghost = block.part(offset, True)
+        values.append(block_vars["hydro_w"][snapy.kIV1][ghost[1:]].reshape(-1))
+    return torch.cat(values)
+
+
+def main():
+    mesh = make_mesh()
+    variables = make_uniform_vertical_velocity_state(mesh)
+
+    mesh.exchange_ghost_zones(variables, snapy.kPrimitive)
+
+    global_min = float("inf")
+    global_max = float("-inf")
+    global_max_abs_error = 0.0
+
+    print(
+        "setup: test_exchange.yaml, cubed-sphere, ideal-gas, "
+        "blocks_per_process=6, local nx2=nx3=6"
+    )
+    print(
+        f"interior vertical velocity kIV1={snapy.kIV1}: "
+        f"{VERTICAL_VELOCITY:.16g}"
+    )
+    print("block loc ghost_min ghost_max max_abs_error")
+
+    for rank, (block, block_vars) in enumerate(zip(mesh.blocks, variables)):
+        values = gather_vertical_velocity_ghost_values(block, block_vars)
+        ghost_min = values.min().item()
+        ghost_max = values.max().item()
+        max_abs_error = torch.max(torch.abs(values - VERTICAL_VELOCITY)).item()
+
+        global_min = min(global_min, ghost_min)
+        global_max = max(global_max, ghost_max)
+        global_max_abs_error = max(global_max_abs_error, max_abs_error)
+
+        loc = tuple(block.get_layout().loc_of(rank))
+        print(
+            f"{rank:5d} {str(loc):9s} "
+            f"{ghost_min:.16g} {ghost_max:.16g} {max_abs_error:.16e}"
+        )
+
+    tolerance = ABS_TOL + REL_TOL * abs(VERTICAL_VELOCITY)
+    ideal_match = global_max_abs_error <= tolerance
+    print(f"global ghost range: [{global_min:.16g}, {global_max:.16g}]")
+    print(f"global max abs error: {global_max_abs_error:.16e}")
+    print(f"tolerance: {tolerance:.16e}")
+    print(f"ideal_match: {ideal_match}")
+
+    assert ideal_match, (
+        "cubed-sphere primitive ghost exchange did not preserve uniform "
+        f"vertical velocity: max_abs_error={global_max_abs_error:.16e}, "
+        f"tolerance={tolerance:.16e}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add cube-sphere velocity transforms that convert between local contravariant components and global spherical polar components. The new helpers derive spherical theta/phi from the panel face name and gnomonic alpha/beta coordinates, then compose with the existing Cartesian and spherical transform utilities.

Update cubed-sphere layout velocity connection data to expose explicit Cartesian-to-local and local-to-Cartesian mappings while keeping the legacy names available. Cross-panel primitive and conserved velocity exchange now serializes through the spherical frame and converts back to the destination panel's contravariant frame on receive.

Expose the new transform helpers through the Python coordinate bindings and type stubs.

Add C++ coverage for contra/spherical round trips, consistency with the Cartesian+spherical composition, and uniform radial spherical velocity. Add a Python regression test that builds an ideal-gas cube-sphere mesh, exchanges ghost zones, and asserts uniform vertical velocity is preserved across panels.