### PR TITLE
examples: add exo3 cubed-sphere dynamical-core benchmarks (W92, HS94,…

### DIFF
--- a/examples/exo3-benchmarks/README.md
+++ b/examples/exo3-benchmarks/README.md
@@ -1,0 +1,52 @@
+# Cubed-sphere dynamical-core benchmarks (exo3)
+
+Three standard dynamical-core benchmarks on the gnomonic-equiangle cubed sphere,
+reproducing the cases from
+[`cshsgy/ExoCubed` `examples/2023-Chen-exo3`](https://github.com/chengcli/ExoCubed)
+(Chen et al. 2023) in `snapy`. Each case is a self-contained Python driver plus a
+YAML config.
+
+| case | driver | config | physics |
+|------|--------|--------|---------|
+| **W92** Williamson (1992) shallow-water test 6 (Rossby–Haurwitz wave) | `w92_swe.py` | `w92.yaml` | shallow-water EOS, `shallow-roe` Riemann, Coriolis |
+| **HS94** Held–Suarez (1994) dry dynamical-core benchmark | `hs94_run.py` | `hs94.yaml` | dry ideal-gas primitive equations, `lmars`, vertical-implicit, Coriolis + HS94 Newtonian-relaxation/Rayleigh forcing (operator-split) |
+| **Hot Jupiter** dry GCM (day–night forced) | `hjupiter_run.py` | `hjupiter.yaml` | dry primitive equations + Newtonian relaxation toward a substellar-hot equilibrium + top Rayleigh sponge |
+
+The HS94 and hot-Jupiter forcings are not built-in `snapy` modules; each driver
+applies them as an operator-split source on the conserved state every step,
+matching the corresponding ExoCubed `Forcing`.
+
+## Running
+
+Each driver starts a distributed run via `paddle.start_dist` using the
+`distribute` block in its config (default `blocks_per_process: 6`, i.e. the six
+cube faces). Launch with `torchrun`:
+
+```bash
+# W92 shallow water (one process holding all 6 faces)
+torchrun --nproc_per_node=1 w92_swe.py --output-dir out_w92
+
+# HS94 dry dynamical core
+torchrun --nproc_per_node=1 hs94_run.py --output-dir out_hs94
+
+# Hot Jupiter
+torchrun --nproc_per_node=1 hjupiter_run.py --output-dir out_hjupiter
+```
+
+Pass `-c <config.yaml>` to override the default config (each driver defaults to
+the YAML next to it). Adjust `distribute` (`blocks_per_process`, `backend`) and
+`CUDA_VISIBLE_DEVICES` for multi-GPU.
+
+## Expected results
+
+- **W92** — the Rossby–Haurwitz wave-4 pattern propagates eastward, retaining its
+  shape; geopotential and winds stay smooth across panel boundaries.
+- **HS94** — relaxes to the classic Held–Suarez climate: midlatitude eddy-driven
+  westerly jets and a realistic zonal-mean temperature structure.
+- **Hot Jupiter** — develops a strong prograde **equatorial superrotating jet**.
+
+## Dependencies
+
+`snapy`, `paddle` (distributed/profile helpers and `paddle.cubed_sphere_remap`
+for the W92 contravariant↔geographic velocity rotation), `torch`, `numpy`,
+`pyyaml`.

--- a/examples/exo3-benchmarks/hjupiter.yaml
+++ b/examples/exo3-benchmarks/hjupiter.yaml
@@ -1,0 +1,36 @@
+reference-state: {Tref: 0., Pref: 1.e5}
+
+species:
+  - name: dry
+    composition: {H: 2, He: 0.05}   # M=2.216 g/mol -> Rd=3752 (H2-dominated); cv_R=2.5 -> gamma=1.4
+    cv_R: 2.5
+    u0_R: 0.
+
+geometry:
+  type: gnomonic-equiangle
+  bounds: {x1min: 1.0e8, x1max: 1.03e8, x2min_pi: -0.25, x2max_pi: 0.25, x3min_pi: -0.25, x3max_pi: 0.25}
+  cells: {nx1: 32, nx2: 48, nx3: 48, nghost: 3}
+
+distribute: {backend: nccl, layout: cubed-sphere, nb2: 1, nb3: 1, blocks_per_process: 6, verbose: false}
+
+dynamics:
+  equation-of-state: {type: ideal-moist, density-floor: 1.e-12, pressure-floor: 1.e-8, tracer-floor: 1.e-12, limiter: true, max-iter: 20, ftol: 1.e-6}
+  vertical-projection: {type: temperature, pressure-margin: 1.e-6}
+  reconstruct:
+    vertical: {type: weno5, scale: true, shock: true}
+    horizontal: {type: weno5, scale: true, shock: true}
+  riemann-solver: {type: hllc}
+
+boundary-condition:
+  external: {x1-inner: reflecting, x1-outer: reflecting, x2-inner: custom, x2-outer: custom, x3-inner: custom, x3-outer: custom}
+
+integration: {type: rk3, cfl: 0.9, implicit-scheme: 9, nlim: -1, tlim: 5.184e7, ncycle_out: 500}
+
+outputs:
+  - {type: netcdf, variables: [prim], dt: 1.728e6}
+
+forcing:
+  const-gravity: {grav1: -8.0}
+  coriolis: {type: xyz, omega1: 2.1e-5}
+
+problem: {Ps: 1.0e5, Ts: 1600., Tmin: 1200.}

--- a/examples/exo3-benchmarks/hjupiter_run.py
+++ b/examples/exo3-benchmarks/hjupiter_run.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Hot-Jupiter dry GCM benchmark in snapy, reproducing cshsgy/ExoCubed
+examples/2023-Chen-exo3/hot_jupiter.{cpp,inp}.
+
+Dry primitive equations on the gnomonic-equiangle cubed sphere (ideal-moist dry
+H2 species, hllc, vertical-implicit) + Coriolis. Forced by Newtonian relaxation
+(fixed timescale Kt) of T toward a day-night equilibrium
+    T_eq = T_vert(z, sigma) + beta(sigma) * dT_e2p * cos(lat) * cos(lon)
+(hottest at the substellar point lon=lat=0) plus a Rayleigh sponge near the top.
+IC: isothermal atmosphere at Ts. Expected: a strong prograde EQUATORIAL
+SUPER-ROTATING jet.
+"""
+import argparse, os, yaml
+import numpy as np, torch
+from snapy import Mesh, MeshOptions, kIDN, kIPR, kIV1, kIV2, kIV3
+from paddle import start_dist, close_dist, setup_profile
+
+FACE_NAMES = ["+X", "+Y", "-X", "+Z", "-Y", "-Z"]
+
+# --- hot-Jupiter parameters (hot_jupiter.cpp / .inp) ---
+G = 8.0; M_MOL = 2.216e-3; RD = 8.31446 / M_MOL; CP = 3.5 * RD; CV = CP - RD
+P0 = 1.0e5; TS = 1600.0; RP = 1.0e8
+DT_E2P = 300.0; DT_STRA = 10.0; Z_STRA = 2.0e6; GAMMA = 2.0e-4
+KT = 1.5e5; SIGMA_STRA = 0.12
+SPONGE_TAU = 1.0e4; SPONGE_Z = 2.5e6
+
+def ab_to_lonlat(face, alpha, beta):
+    x = np.tan(alpha); y = np.tan(beta); r = np.sqrt(x*x + y*y + 1.0)
+    if face == "+X":   lon = alpha.copy();              lat = np.arctan(y/np.sqrt(1+x*x))
+    elif face == "+Y": lon = alpha + 0.5*np.pi;         lat = np.arctan(y/np.sqrt(1+x*x))
+    elif face == "-X": lon = alpha + np.pi;             lat = np.arctan(y/np.sqrt(1+x*x))
+    elif face == "-Y": lon = alpha + 1.5*np.pi;         lat = np.arctan(y/np.sqrt(1+x*x))
+    elif face == "+Z": lon = np.arctan2(x, -y);         lat = np.arcsin(1.0/r)
+    elif face == "-Z": lon = np.arctan2(x,  y);         lat = -np.arcsin(1.0/r)
+    else: raise ValueError(face)
+    lon = np.where(lon < 0.0, lon + 2*np.pi, lon)
+    return lon, lat
+
+def hj_forcing(hw, hu, coslat, coslon, z, dt):
+    """Operator-split hot-Jupiter source on conserved hu (in place).
+    coslat,coslon: (nc3,nc2,1); z: (1,1,nc1)."""
+    rho = hw[kIDN]; p = hw[kIPR]
+    T = p / (rho * RD); sigma = p / P0
+    below = (z <= Z_STRA).double()
+    T_vert = below * (TS - GAMMA*(Z_STRA + z)/2.0 + torch.sqrt((GAMMA*(z - Z_STRA)/2.0)**2 + DT_STRA**2)) \
+           + (1.0 - below) * (TS - GAMMA*Z_STRA + DT_STRA)
+    beta = below * torch.sin(np.pi*(sigma - SIGMA_STRA)/(2.0*(1.0 - SIGMA_STRA)))
+    Teq = T_vert + beta * DT_E2P * coslat * coslon
+    # Newtonian relaxation (fixed timescale Kt) on total energy (internal = rho*cv*T)
+    hu[kIPR] += -dt * CV * rho * (T - Teq) / KT
+    # top Rayleigh sponge on (covariant) momentum
+    spng = (z > SPONGE_Z).double()
+    damp = 1.0 / (1.0 + spng * dt / SPONGE_TAU)
+    hu[kIV1] *= damp; hu[kIV2] *= damp; hu[kIV3] *= damp
+
+def run(args):
+    with open(args.config) as f: config = yaml.safe_load(f)
+    device = start_dist(config["distribute"].get("backend", "gloo"))
+    opt = MeshOptions.from_yaml(args.config); opt.block().output_dir(args.output_dir)
+    mesh = Mesh(opt); mesh.to(device)
+
+    global RD, CV, CP
+    geom = []   # per-block (coslat, coslon, z)
+    block_vars = []
+    for f, block in enumerate(mesh.blocks):
+        coord = block.module("coord")
+        x1v = coord.buffer("x1v").cpu().numpy()
+        x2v = coord.buffer("x2v").cpu().numpy(); x3v = coord.buffer("x3v").cpu().numpy()
+        alpha, beta = np.meshgrid(x2v, x3v)                    # (nc3,nc2)
+        lon, lat = ab_to_lonlat(FACE_NAMES[f], alpha, beta)
+        coslat = torch.from_numpy(np.cos(lat)[..., None]).to(device, torch.float64)
+        coslon = torch.from_numpy(np.cos(lon)[..., None]).to(device, torch.float64)
+        z = torch.from_numpy((x1v - RP)[None, None, :]).to(device, torch.float64)
+        geom.append((coslat, coslon, z))
+        w = setup_profile(block, {"Ts": TS, "Ps": P0, "grav": G, "Tmin": 1200.0}, method="isothermal")
+        if f == 0:   # calibrate Rd from the isothermal IC (T = p/(rho*Rd) = Ts)
+            il, jl, kl = coord.il(), coord.jl(), coord.kl()
+            RD = float(w[kIPR][kl, jl, il] / w[kIDN][kl, jl, il]) / TS
+            CV = 2.5 * RD; CP = 3.5 * RD
+            print(f"calibrated Rd={RD:.1f} J/kg/K  cp={CP:.1f}  cv={CV:.1f}", flush=True)
+        w[kIV1] = 0.0; w[kIV2] = 0.0; w[kIV3] = 0.0
+        block_vars.append({"hydro_w": w})
+    block_vars, current_time = mesh.initialize(block_vars)
+
+    intg = mesh.module("block0.intg"); cycle = 0
+    mesh.make_outputs(block_vars, current_time)
+    while not intg.stop(cycle, current_time):
+        cycle += 1; mesh.set_cycle(cycle)
+        dt = mesh.max_time_step(block_vars)
+        mesh.print_cycle_info(block_vars, current_time, dt)
+        for stage in range(len(intg.stages)):
+            mesh.forward(block_vars, dt, stage)
+        for bv, block, (cla, clo, z) in zip(block_vars, mesh.blocks, geom):
+            hj_forcing(bv["hydro_w"], bv["hydro_u"], cla, clo, z, dt)
+            bv["hydro_w"] = block.module("hydro.eos").compute("U->W", [bv["hydro_u"]])
+        err = mesh.check_redo(block_vars)
+        if err > 0: continue
+        if err < 0: break
+        current_time += dt
+        mesh.make_outputs(block_vars, current_time)
+    mesh.finalize(block_vars, current_time)
+    close_dist()
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("-c", "--config", default=os.path.join(os.path.dirname(__file__), "hjupiter.yaml"))
+    p.add_argument("--output-dir", default="/data/2026.JupiterCRM/hjupiter")
+    run(p.parse_args())

--- a/examples/exo3-benchmarks/hs94.yaml
+++ b/examples/exo3-benchmarks/hs94.yaml
@@ -1,0 +1,36 @@
+reference-state: {Tref: 0., Pref: 1.e5}
+
+species:
+  - name: dry
+    composition: {N: 1.5, O: 0.5}   # M=29 g/mol -> Rd=286.7 ; cv_R=2.5 -> gamma=1.4, cp=1003
+    cv_R: 2.5
+    u0_R: 0.
+
+geometry:
+  type: gnomonic-equiangle
+  bounds: {x1min: 6.371e6, x1max: 6.396e6, x2min_pi: -0.25, x2max_pi: 0.25, x3min_pi: -0.25, x3max_pi: 0.25}
+  cells: {nx1: 40, nx2: 48, nx3: 48, nghost: 3}
+
+distribute: {backend: nccl, layout: cubed-sphere, nb2: 1, nb3: 1, blocks_per_process: 6, verbose: false}
+
+dynamics:
+  equation-of-state: {type: ideal-moist, density-floor: 1.e-10, pressure-floor: 1.e-10, tracer-floor: 1.e-10, limiter: true, max-iter: 20, ftol: 1.e-6}
+  vertical-projection: {type: temperature, pressure-margin: 1.e-6}
+  reconstruct:
+    vertical: {type: weno5, scale: true, shock: true}
+    horizontal: {type: weno5, scale: true, shock: true}
+  riemann-solver: {type: lmars}
+
+boundary-condition:
+  external: {x1-inner: reflecting, x1-outer: reflecting, x2-inner: custom, x2-outer: custom, x3-inner: custom, x3-outer: custom}
+
+integration: {type: rk3, cfl: 0.9, implicit-scheme: 9, nlim: -1, tlim: 2.592e7, ncycle_out: 500}
+
+outputs:
+  - {type: netcdf, variables: [prim], dt: 8.64e5}
+
+forcing:
+  const-gravity: {grav1: -9.81}
+  coriolis: {type: xyz, omega1: 7.292e-5}
+
+problem: {Ps: 1.0e5, Ts: 315., Tmin: 120.}

--- a/examples/exo3-benchmarks/hs94_run.py
+++ b/examples/exo3-benchmarks/hs94_run.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Held-Suarez 1994 dry dynamical-core benchmark in snapy, reproducing
+cshsgy/ExoCubed examples/2023-Chen-exo3/hs94.{cpp,inp}.
+
+Dry primitive equations on the gnomonic-equiangle cubed sphere (snapy `ideal-gas`
+EOS, lmars, vertical-implicit), Coriolis via the `coriolis` forcing. The HS94
+forcing — Newtonian relaxation of T toward Teq(lat,sigma) and low-level Rayleigh
+friction — is not a built-in snapy module, so it is applied as an operator-split
+source on the conserved state each step (matching the ExoCubed `Forcing`).
+IC: dry-adiabatic hydrostatic profile (theta=Ts up to z_iso, then isothermal),
+seeded with small random horizontal velocity.
+"""
+import argparse, os, yaml
+import numpy as np, torch
+from snapy import Mesh, MeshOptions, kIDN, kIPR, kIV1, kIV2, kIV3
+from paddle import start_dist, close_dist, setup_profile
+
+FACE_NAMES = ["+X", "+Y", "-X", "+Z", "-Y", "-Z"]
+
+# --- HS94 + Earth dry-air parameters (from hs94.cpp / hs94.inp) ---
+# Rd/cp from the snapy "dry" species (M=29 g/mol, cv_R=2.5 -> gamma=1.4)
+G = 9.81; RD = 8.31446 / 0.029; CP = 3.5 * RD; CV = CP - RD; KAPPA = RD / CP
+P0 = 1.0e5; TS = 315.0; DT_h = 60.0; DTHETA = 10.0
+SIGMAB = 0.7; Z_ISO = 2.0e4; RP = 6.371e6
+DAY = 86400.0
+KF = 1.0 / DAY; KA = 0.025 / DAY; KS = 0.25 / DAY
+TEQ_FLOOR = 200.0
+
+def ab_to_lat(face, alpha, beta):
+    x = np.tan(alpha); y = np.tan(beta); r = np.sqrt(x*x + y*y + 1.0)
+    if face in ("+X", "+Y", "-X", "-Y"): lat = np.arctan(y/np.sqrt(1+x*x))
+    elif face == "+Z": lat = np.arcsin(1.0/r)
+    elif face == "-Z": lat = -np.arcsin(1.0/r)
+    else: raise ValueError(face)
+    return lat
+
+def dry_adiabat_profile(z):
+    """T(z), p(z), rho(z): dry adiabat (theta=Ts) up to z_iso, isothermal above."""
+    z = np.asarray(z, dtype=np.float64)
+    T_iso = TS - G * Z_ISO / CP
+    p_iso = P0 * (T_iso / TS) ** (CP / RD)
+    T = np.where(z <= Z_ISO, TS - (G / CP) * z, T_iso)
+    p = np.where(z <= Z_ISO,
+                 P0 * (np.clip(TS - (G/CP)*z, 1.0, None) / TS) ** (CP/RD),
+                 p_iso * np.exp(-G * (z - Z_ISO) / (RD * T_iso)))
+    rho = p / (RD * T)
+    return T, p, rho
+
+def hs_forcing(hw, hu, lat_col, dt):
+    """Operator-split HS94 source on conserved state hu (in place).
+    hw,hu: (5, nc3, nc2, nc1); lat_col: (nc3, nc2, 1) latitude broadcast over height."""
+    rho = hw[kIDN]; p = hw[kIPR]
+    T = p / (rho * RD); sigma = p / P0
+    coslat = torch.cos(lat_col); sinlat = torch.sin(lat_col)
+    Teq = (TS - DT_h * sinlat**2 - DTHETA * torch.log(torch.clamp(sigma, min=1e-12)) * coslat**2) * sigma**KAPPA
+    Teq = torch.clamp(Teq, min=TEQ_FLOOR)
+    sigma_p = torch.clamp((sigma - SIGMAB) / (1.0 - SIGMAB), min=0.0)
+    Kv = sigma_p * KF
+    Kt = KA + (KS - KA) * sigma_p * coslat**4
+    # Newtonian cooling on total energy (internal energy = rho*cv*T)
+    hu[kIPR] += -dt * rho * CV * Kt * (T - Teq)
+    # low-level Rayleigh friction on (covariant) momentum, implicit/stable
+    damp = 1.0 / (1.0 + dt * Kv)
+    hu[kIV1] *= damp; hu[kIV2] *= damp; hu[kIV3] *= damp
+
+def run(args):
+    with open(args.config) as f: config = yaml.safe_load(f)
+    device = start_dist(config["distribute"].get("backend", "gloo"))
+    opt = MeshOptions.from_yaml(args.config); opt.block().output_dir(args.output_dir)
+    mesh = Mesh(opt); mesh.to(device)
+    rng = np.random.default_rng(0)
+
+    lats = []           # per-block (nc3,nc2,1) latitude
+    block_vars = []
+    for f, block in enumerate(mesh.blocks):
+        coord = block.module("coord")
+        x1v = coord.buffer("x1v").cpu().numpy()
+        x2v = coord.buffer("x2v").cpu().numpy(); x3v = coord.buffer("x3v").cpu().numpy()
+        alpha, beta = np.meshgrid(x2v, x3v)                    # (nc3,nc2)
+        lat2d = ab_to_lat(FACE_NAMES[f], alpha, beta)          # (nc3,nc2)
+        lats.append(torch.from_numpy(lat2d[..., None]).to(device, torch.float64))
+        # dry-adiabatic hydrostatic IC (theta=Ts up to where T hits Tmin, then isothermal)
+        w = setup_profile(block, {"Ts": TS, "Ps": P0, "grav": G, "Tmin": 120.0}, method="dry-adiabat")
+        w[kIV1] = 0.0
+        # start from rest: grid-scale white-noise seeding drives negative density at the
+        # cube corners; the cubed-sphere grid's zonal asymmetry seeds the baroclinic eddies.
+        _ = x1v  # (kept for reference; no explicit perturbation)
+        block_vars.append({"hydro_w": w})
+    block_vars, current_time = mesh.initialize(block_vars)
+
+    intg = mesh.module("block0.intg"); cycle = 0
+    mesh.make_outputs(block_vars, current_time)
+    while not intg.stop(cycle, current_time):
+        cycle += 1; mesh.set_cycle(cycle)
+        dt = mesh.max_time_step(block_vars)
+        mesh.print_cycle_info(block_vars, current_time, dt)
+        for stage in range(len(intg.stages)):
+            mesh.forward(block_vars, dt, stage)
+        # HS94 Newtonian cooling + Rayleigh drag (operator split), then refresh prim
+        for bv, block, lat_col in zip(block_vars, mesh.blocks, lats):
+            hs_forcing(bv["hydro_w"], bv["hydro_u"], lat_col, dt)
+            bv["hydro_w"] = block.module("hydro.eos").compute("U->W", [bv["hydro_u"]])
+        err = mesh.check_redo(block_vars)
+        if err > 0: continue
+        if err < 0: break
+        current_time += dt
+        mesh.make_outputs(block_vars, current_time)
+    mesh.finalize(block_vars, current_time)
+    close_dist()
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("-c", "--config", default=os.path.join(os.path.dirname(__file__), "hs94.yaml"))
+    p.add_argument("--output-dir", default="/data/2026.JupiterCRM/hs94")
+    run(p.parse_args())

--- a/examples/exo3-benchmarks/w92.yaml
+++ b/examples/exo3-benchmarks/w92.yaml
@@ -1,0 +1,61 @@
+geometry:
+  type: gnomonic-equiangle
+  bounds:
+    x1min: 6371000.0
+    x1max: 6371001.0
+    x2min_pi: -0.25
+    x2max_pi: 0.25
+    x3min_pi: -0.25
+    x3max_pi: 0.25
+  cells:
+    nx1: 1
+    nx2: 96
+    nx3: 96
+    nghost: 3
+distribute:
+  backend: nccl
+  layout: cubed-sphere
+  nb2: 1
+  nb3: 1
+  blocks_per_process: 6
+  verbose: false
+dynamics:
+  equation-of-state:
+    type: shallow-water
+  reconstruct:
+    vertical:
+      type: weno5
+      scale: false
+      shock: false
+    horizontal:
+      type: weno5
+      scale: false
+      shock: false
+  riemann-solver:
+    type: shallow-roe
+    dir: yz
+boundary-condition:
+  external:
+    x1-inner: reflecting
+    x1-outer: reflecting
+    x2-inner: custom
+    x2-outer: custom
+    x3-inner: custom
+    x3-outer: custom
+integration:
+  type: rk3
+  cfl: 0.7
+  nlim: -1
+  tlim: 3456000.0
+  ncycle_out: 200
+outputs:
+- type: netcdf
+  variables:
+  - prim
+  dt: 14400.0
+forcing:
+  coriolis:
+    type: xyz
+    omega1: 7.292e-05
+problem:
+  note: Williamson-1992 test case 6 Rossby-Haurwitz wave; IC set in driver

--- a/examples/exo3-benchmarks/w92_swe.py
+++ b/examples/exo3-benchmarks/w92_swe.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Williamson (1992) shallow-water test case 6 — Rossby-Haurwitz wave — in snapy,
+reproducing cshsgy/ExoCubed examples/2023-Chen-exo3/W92.{cpp,inp}.
+
+Shallow water on the gnomonic-equiangle cubed sphere (snapy `shallow-water` EOS,
+`shallow-roe` Riemann solver), Coriolis via the `coriolis` forcing. The
+Rossby-Haurwitz initial condition (geopotential gh + winds U,V) is set per cell
+using snapy's exact (face,xi,eta)->(lon,lat) map; physical (U,V) east/north are
+converted to snapy contravariant (vel2,vel3) by inverting the validated
+elijah-mullens/paddle contra->geographic rotation per cell.
+"""
+import argparse, os, yaml
+import numpy as np
+import torch
+from snapy import Mesh, MeshOptions
+from paddle import start_dist, close_dist
+# paddle velocity rotation (contravariant -> global Cartesian)
+from paddle import cubed_sphere_remap as csr
+
+FACE_NAMES = ["+X", "+Y", "-X", "+Z", "-Y", "-Z"]   # snapy CS_FACE_NAMES (face-major order)
+
+# --- Rossby-Haurwitz parameters (from W92.cpp) ---
+h0 = 8000.0; G = 9.80616; OMG = 7.848e-6; A = 6.37122e6
+K = 7.848e-6; R = 4.0; OM_EARTH = 7.292e-5
+
+def ab_to_lonlat(face, alpha, beta):
+    """snapy cs_ab_to_lonlat: equiangular (xi=alpha, eta=beta) -> (lon[0,2pi], lat)."""
+    x = np.tan(alpha); y = np.tan(beta); r = np.sqrt(x*x + y*y + 1.0)
+    if face == "+X":   lon = alpha.copy();              lat = np.arctan(y/np.sqrt(1+x*x))
+    elif face == "+Y": lon = alpha + 0.5*np.pi;         lat = np.arctan(y/np.sqrt(1+x*x))
+    elif face == "-X": lon = alpha + np.pi;             lat = np.arctan(y/np.sqrt(1+x*x))
+    elif face == "-Y": lon = alpha + 1.5*np.pi;         lat = np.arctan(y/np.sqrt(1+x*x))
+    elif face == "+Z": lon = np.arctan2(x, -y);         lat = np.arcsin(1.0/r)
+    elif face == "-Z": lon = np.arctan2(x,  y);         lat = -np.arcsin(1.0/r)
+    else: raise ValueError(face)
+    lon = np.where(lon < 0.0, lon + 2*np.pi, lon)
+    return lon, lat
+
+def rh_wave(lon, lat):
+    """Rossby-Haurwitz geopotential gh and physical winds U (east), V (north)."""
+    cl = np.cos(lat); sl = np.sin(lat)
+    Aa = 0.5*OMG*(2*OM_EARTH+OMG)*cl**2 + 0.25*K*K*(
+        (R+1)*cl**(2*R+2) + (2*R*R-R-2)*cl**(2*R) - 2*R*R*cl**(2*R-2))
+    Bb = 2*(OM_EARTH+OMG)*K/((R+1)*(R+2))*cl**R*((R*R+2*R+2) - (R+1)**2*cl**2)
+    Cc = 0.25*K*K*cl**(2*R)*((R+1)*cl**2 - (R+2))
+    gh = G*h0 + A*A*Aa + A*A*Bb*np.cos(R*lon) + A*A*Cc*np.cos(2*R*lon)
+    U = A*OMG*cl + A*K*cl**(R-1)*np.cos(R*lon)*(R*sl*sl - cl*cl)
+    V = -A*K*R*cl**(R-1)*np.sin(R*lon)*sl
+    return gh, U, V
+
+def uv_to_contra(face_id, alpha, beta, lon, lat, U, V):
+    """(U east, V north) -> snapy contravariant (vel2, vel3) by inverting the
+    per-cell 2x2 contra->east/north map (vel1=0, tangential flow)."""
+    def east_north(v2, v3):
+        gx, gy, gz = csr._local_contra_to_global_xyz(
+            face_id, np.zeros_like(v2), v2, v3, alpha, beta)
+        east  = -np.sin(lon)*gx + np.cos(lon)*gy
+        north = -np.sin(lat)*np.cos(lon)*gx - np.sin(lat)*np.sin(lon)*gy + np.cos(lat)*gz
+        return east, north
+    one = np.ones_like(alpha); zero = np.zeros_like(alpha)
+    e1, n1 = east_north(one, zero)    # response to vel2=1
+    e2, n2 = east_north(zero, one)    # response to vel3=1
+    det = e1*n2 - e2*n1
+    vel2 = ( n2*U - e2*V)/det
+    vel3 = (-n1*U + e1*V)/det
+    return vel2, vel3
+
+def run(args):
+    with open(args.config) as f: config = yaml.safe_load(f)
+    device = start_dist(config["distribute"].get("backend", "gloo"))
+    opt = MeshOptions.from_yaml(args.config); opt.block().output_dir(args.output_dir)
+    mesh = Mesh(opt); mesh.to(device)
+
+    block_vars = []
+    for f, block in enumerate(mesh.blocks):
+        coord = block.module("coord")
+        x2v = coord.buffer("x2v").cpu().numpy()   # xi (nc2,)
+        x3v = coord.buffer("x3v").cpu().numpy()   # eta (nc3,)
+        nc2, nc3 = x2v.size, x3v.size
+        alpha, beta = np.meshgrid(x2v, x3v)       # shape (nc3, nc2): [k,j]
+        lon, lat = ab_to_lonlat(FACE_NAMES[f], alpha, beta)
+        gh, U, V = rh_wave(lon, lat)
+        vel2, vel3 = uv_to_contra(f, alpha, beta, lon, lat, U, V)
+        w = torch.zeros((4, nc3, nc2, 1), dtype=torch.float64)
+        w[0, :, :, 0] = torch.from_numpy(gh)
+        w[1, :, :, 0] = 0.0
+        w[2, :, :, 0] = torch.from_numpy(vel2)
+        w[3, :, :, 0] = torch.from_numpy(vel3)
+        block_vars.append({"hydro_w": w.to(device)})
+    block_vars, current_time = mesh.initialize(block_vars)
+
+    intg = mesh.module("block0.intg")
+    cycle = 0
+    mesh.make_outputs(block_vars, current_time)
+    while not intg.stop(cycle, current_time):
+        cycle += 1
+        mesh.set_cycle(cycle)
+        dt = mesh.max_time_step(block_vars)
+        mesh.print_cycle_info(block_vars, current_time, dt)
+        for stage in range(len(intg.stages)):
+            mesh.forward(block_vars, dt, stage)
+        err = mesh.check_redo(block_vars)
+        if err > 0: continue
+        if err < 0: break
+        current_time += dt
+        mesh.make_outputs(block_vars, current_time)
+    mesh.finalize(block_vars, current_time)
+    close_dist()
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("-c", "--config",
+                   default=os.path.join(os.path.dirname(__file__), "w92.yaml"))
+    p.add_argument("--output-dir", default="/data/2026.JupiterCRM/w92")
+    run(p.parse_args())


### PR DESCRIPTION
… hot Jupiter)

Python reproductions of cshsgy/ExoCubed examples/2023-Chen-exo3:
- W92: Williamson (1992) shallow-water test 6 (Rossby-Haurwitz wave)
- HS94: Held-Suarez (1994) dry dynamical-core benchmark
- hot Jupiter: dry GCM with day-night Newtonian relaxation -> equatorial superrotation

Each is a self-contained driver + YAML config on the gnomonic-equiangle cubed sphere. HS94 / hot-Jupiter forcings applied as operator-split sources.